### PR TITLE
change some #[cfg] tests to export functions on linux

### DIFF
--- a/hotham-simulator/build.rs
+++ b/hotham-simulator/build.rs
@@ -2,7 +2,7 @@ use std::{fs, path::Path, str};
 
 use shaderc::{Compiler, ShaderKind};
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "linux"))]
 fn main() {
     println!("cargo:rerun-if-changed=build_input");
     // The bindgen::Builder is the main entry point

--- a/hotham/src/resources/xr_context.rs
+++ b/hotham/src/resources/xr_context.rs
@@ -214,7 +214,7 @@ impl XrContext {
     }
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "linux"))]
 pub(crate) fn create_vulkan_context(
     xr_instance: &xr::Instance,
     system: xr::SystemId,

--- a/hotham/src/texture.rs
+++ b/hotham/src/texture.rs
@@ -139,7 +139,7 @@ impl Texture {
     }
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "linux"))]
 fn parse_image(path: &str) -> Result<(Vec<u8>, u32, u32)> {
     let path = format!(r#"..\test_assets\\{}"#, path);
     let img = ImageReader::open(path)?.decode()?;


### PR DESCRIPTION
This relaxes some of the cfg tests so that relevant functions are defined on linux. This enables hotham to build at least on linux (ubuntu 20.04).

I am not able to run examples, as I do not have the openxr_loader.so file, as there don't appear to be any ubuntu packages.

Cheers