### PR TITLE
Add support for collider transforms

### DIFF
--- a/examples/beat-saber-clone/Cargo.toml
+++ b/examples/beat-saber-clone/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 [dependencies]
 hotham = {path = "../../hotham"}
 hotham-debug-server = {path = "../../hotham-debug-server"}
+nalgebra = {version = "0.29.0"}
 
 [target.'cfg(target_os = "android")'.dependencies]
 ndk-glue = "0.4.0"

--- a/examples/beat-saber-clone/src/lib.rs
+++ b/examples/beat-saber-clone/src/lib.rs
@@ -1,5 +1,6 @@
 use hotham::gltf_loader::add_model_to_world;
 use hotham::legion::{Resources, Schedule, World};
+use hotham::rapier3d::na::vector;
 use hotham::rapier3d::prelude::{ColliderBuilder, RigidBodyBuilder};
 use hotham::resources::{PhysicsContext, RenderContext, XrContext};
 use hotham::schedule_functions::{begin_frame, end_frame, physics_step, sync_debug_server};
@@ -34,15 +35,30 @@ pub fn real_main() -> HothamResult<()> {
         .expect("Unable to add Blue Cube");
     let red_cube =
         add_model_to_world("Red Cube", &models, &mut world, None).expect("Unable to add Red Cube");
-    add_model_to_world("Blue Saber", &models, &mut world, None).expect("Unable to add Blue Saber");
+    let blue_saber = add_model_to_world("Blue Saber", &models, &mut world, None)
+        .expect("Unable to add Blue Saber");
     add_model_to_world("Red Saber", &models, &mut world, None).expect("Unable to add Red Saber");
     add_model_to_world("Environment", &models, &mut world, None)
         .expect("Unable to add Environment");
     add_model_to_world("Ramp", &models, &mut world, None).expect("Unable to add Ramp");
 
     // Add test physics objects
-    let rigid_body = RigidBodyBuilder::new_dynamic().build();
+    let rigid_body = RigidBodyBuilder::new_dynamic()
+        .translation(vector![0., 5., 0.])
+        .build();
     let collider = ColliderBuilder::cylinder(1.0, 0.2).build();
+    let (rigid_body, collider) =
+        physics_context.add_rigid_body_and_collider(blue_saber, rigid_body, collider);
+    {
+        let mut entry = world.entry(blue_saber).unwrap();
+        entry.add_component(rigid_body);
+        entry.add_component(collider);
+    }
+
+    let rigid_body = RigidBodyBuilder::new_dynamic().build();
+    let collider = ColliderBuilder::cuboid(1.0, 1.0, 1.0)
+        .translation(vector![0., 1.0, 0.])
+        .build();
     let (rigid_body, collider) =
         physics_context.add_rigid_body_and_collider(blue_cube, rigid_body, collider);
     {
@@ -52,11 +68,13 @@ pub fn real_main() -> HothamResult<()> {
     }
 
     let rigid_body = RigidBodyBuilder::new_dynamic().build();
-    let collider = ColliderBuilder::cuboid(1.0, 1.0, 1.0).build();
+    let collider = ColliderBuilder::cuboid(1.0, 1.0, 1.0)
+        .translation(vector![0., 1., 0.])
+        .build();
     let (rigid_body, collider) =
         physics_context.add_rigid_body_and_collider(red_cube, rigid_body, collider);
     {
-        let mut entry = world.entry(blue_cube).unwrap();
+        let mut entry = world.entry(red_cube).unwrap();
         entry.add_component(rigid_body);
         entry.add_component(collider);
     }

--- a/hotham-debug-frontend/src/App.test.tsx
+++ b/hotham-debug-frontend/src/App.test.tsx
@@ -51,6 +51,7 @@ const stubFrames: Frame[] = [
         collider: {
           colliderType: 'cube',
           geometry: [1, 2, 3],
+          translation: [0, 0.5, 0],
         },
       },
       1: {
@@ -279,6 +280,9 @@ test('clicking on an entity shows details about that entity', async () => {
     expect(inspectorContainer).toHaveTextContent('translation: x: 0 y: 0 z: 0');
     expect(inspectorContainer).toHaveTextContent('rotation: x: 0 y: 0 z: 0');
     expect(inspectorContainer).toHaveTextContent('scale: x: 1 y: 1 z: 1');
+    expect(inspectorContainer).toHaveTextContent(
+      'translation: x: 0 y: 0.5 z: 0'
+    );
   });
 });
 

--- a/hotham-debug-frontend/src/App.tsx
+++ b/hotham-debug-frontend/src/App.tsx
@@ -139,15 +139,18 @@ const LoadingContainer = styled.div`
   color: #fff;
 `;
 
+export type Vector3 = [number, number, number];
+
 export interface Transform {
-  translation: [number, number, number];
-  rotation: [number, number, number];
-  scale: [number, number, number];
+  translation: Vector3;
+  rotation: Vector3;
+  scale: Vector3;
 }
 
 export interface Collider {
   colliderType: 'cube' | 'cylinder';
   geometry: number[];
+  translation: Vector3;
 }
 
 export interface Entity {

--- a/hotham-debug-frontend/src/components/Inspector.tsx
+++ b/hotham-debug-frontend/src/components/Inspector.tsx
@@ -1,7 +1,5 @@
-import React from 'react';
 import styled from 'styled-components';
 import { Collider, Entity, Transform } from '../App';
-import { Timeline } from './Timeline';
 
 const Container = styled.div`
   display: flex;
@@ -58,6 +56,12 @@ function ColliderInspector({ c }: { c?: Collider }): JSX.Element | null {
         <strong>type:</strong> {c.colliderType}
         <br />
         <strong>geometry:</strong> {c.geometry}
+        <br />
+        <strong>translation: </strong>
+        <Indent>
+          <strong>x:</strong> {c.translation[0]} <strong>y:</strong>{' '}
+          {c.translation[1]} <strong>z:</strong> {c.translation[2]}
+        </Indent>
       </Indent>
     </Indent>
   );

--- a/hotham-debug-frontend/src/components/Viewer.tsx
+++ b/hotham-debug-frontend/src/components/Viewer.tsx
@@ -117,25 +117,33 @@ function getPhsicsObjects(
 ): JSX.Element[] | [] {
   const elements: JSX.Element[] = [];
   Object.values(entities).forEach((e) => {
-    if (e.collider?.colliderType === 'cube') {
+    const { collider, transform } = e;
+    if (!collider) return;
+
+    const { colliderType, geometry, translation } = collider;
+    const rotation = getRotation(transform!); // safe: entity with collider and no transform is non-sensical
+
+    if (colliderType === 'cube') {
       elements.push(
         <Box
-          position={e.transform!.translation}
-          args={[
-            e.collider.geometry[0] * 2,
-            e.collider.geometry[1] * 2,
-            e.collider.geometry[2] * 2,
-          ]}
+          position={translation}
+          rotation={rotation}
+          args={[geometry[0] * 2, geometry[1] * 2, geometry[2] * 2]}
         >
           <meshPhongMaterial attach="material" color="#bbb" wireframe />
         </Box>
       );
     }
-    if (e.collider?.colliderType === 'cylinder') {
-      const height = e.collider.geometry[0] * 2;
-      const radius = e.collider.geometry[1];
+
+    if (colliderType === 'cylinder') {
+      const height = geometry[0] * 2;
+      const radius = geometry[1];
       elements.push(
-        <Cylinder args={[radius, radius, height]}>
+        <Cylinder
+          args={[radius, radius, height]}
+          position={translation}
+          rotation={rotation}
+        >
           <meshPhongMaterial attach="material" color="#bbb" wireframe />
         </Cylinder>
       );

--- a/hotham-debug-server/src/debug_frame.rs
+++ b/hotham-debug-server/src/debug_frame.rs
@@ -45,15 +45,16 @@ impl PartialEq for DebugTransform {
     }
 }
 
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct DebugCollider {
     pub collider_type: String,
     pub geometry: Vec<f32>,
+    pub translation: [f32; 3],
 }
 
-impl PartialEq for DebugCollider {
-    fn eq(&self, other: &Self) -> bool {
-        self.collider_type == other.collider_type && self.geometry == other.geometry
-    }
-}
+// impl PartialEq for DebugCollider {
+//     fn eq(&self, other: &Self) -> bool {
+//         self.collider_type == other.collider_type && self.geometry == other.geometry
+//     }
+// }

--- a/hotham/src/schedule_functions/sync_debug_server.rs
+++ b/hotham/src/schedule_functions/sync_debug_server.rs
@@ -92,9 +92,13 @@ fn parse_collider(collider: &rapier3d::geometry::Collider) -> DebugCollider {
         vec![cylinder.half_height, cylinder.radius]
     };
 
+    let t = collider.translation();
+    let translation = [t[0], t[1], t[2]];
+
     DebugCollider {
         collider_type: collider_type.to_string(),
         geometry,
+        translation,
     }
 }
 
@@ -128,7 +132,9 @@ mod tests {
         ));
 
         let rigid_body = RigidBodyBuilder::new_dynamic().build();
-        let collider = ColliderBuilder::cuboid(1.0, 1.0, 1.0).build();
+        let collider = ColliderBuilder::cuboid(1.0, 1.0, 1.0)
+            .translation(vector![0., 0.5, 0.])
+            .build();
         let (rigid_body, collider) =
             physics_context.add_rigid_body_and_collider(e1, rigid_body, collider);
         {
@@ -175,6 +181,14 @@ mod tests {
                 translation: [1., 2., 3.],
                 rotation: [0.1, 0.2, 0.3],
                 scale: [3., 2., 1.]
+            })
+        );
+        assert_eq!(
+            debug_entity1.collider,
+            Some(DebugCollider {
+                collider_type: "cube".to_string(),
+                geometry: vec![1., 1., 1.,],
+                translation: [0., 0.5, 0.],
             })
         );
 


### PR DESCRIPTION
- Use the `collider.transform` property to have it be offset wrt its parent
- Added `translation` property to `DebugCollider` object
- Added collider specific translation and rotation to Viewer

Closes #103