### PR TITLE
Handle Android/OpenXR lifecycle correctly

### DIFF
--- a/examples/beat-saber-clone/src/lib.rs
+++ b/examples/beat-saber-clone/src/lib.rs
@@ -47,7 +47,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(target_os = "android", ndk_glue::main(backtrace = "on"))]
 pub fn main() {
     println!("[BEAT_SABER_EXAMPLE] MAIN!");
-    real_main().unwrap();
+    real_main().expect("[BEAT_SABER_EXAMPLE] ERROR IN MAIN!");
 }
 
 #[cfg(target_os = "android")]

--- a/hotham/src/resources/xr_context.rs
+++ b/hotham/src/resources/xr_context.rs
@@ -197,26 +197,14 @@ impl XrContext {
             match self.instance.poll_event(event_buffer)? {
                 Some(xr::Event::SessionStateChanged(session_changed)) => {
                     let new_state = session_changed.state();
-
-                    if self.session_state == SessionState::IDLE && new_state == SessionState::READY
-                    {
-                        println!("[HOTHAM_POLL_EVENT] Beginning session!");
-                        self.session.begin(VIEW_TYPE)?;
-                    }
-
-                    if self.session_state != SessionState::STOPPING
-                        && new_state == SessionState::STOPPING
-                    {
-                        println!("[HOTHAM_POLL_EVENT] Ending session!");
-                        self.session.end()?;
-                    }
-
                     println!("[HOTHAM_POLL_EVENT] State is now {:?}", new_state);
                     self.session_state = new_state;
                 }
-                Some(_) => {
-                    println!("[HOTHAM_POLL_EVENT] Received some other event");
+                Some(xr::Event::InstanceLossPending(_)) => {
+                    println!("[HOTHAM_POLL_EVENT] Instance loss pending!");
+                    break;
                 }
+                Some(_) => println!("[HOTHAM_POLL_EVENT] Received some other event"),
                 None => break,
             }
         }
@@ -275,6 +263,13 @@ impl XrContext {
 
         let layers = [&*layer_projection];
         self.frame_stream.end(display_time, BLEND_MODE, &layers)
+    }
+
+    pub(crate) fn end_session(&mut self) -> anyhow::Result<()> {
+        println!("[HOTHAM_XR] - Ending session..");
+        self.session.end()?;
+        println!("[HOTHAM_XR] - ..done!");
+        Ok(())
     }
 }
 

--- a/hotham/src/schedule_functions/begin_frame.rs
+++ b/hotham/src/schedule_functions/begin_frame.rs
@@ -36,7 +36,14 @@ pub fn begin_frame(_world: &mut World, resources: &mut Resources) {
     xr_context.views = views;
     xr_context.view_state_flags = view_state_flags;
 
-    render_context.begin_frame(&vulkan_context, available_swapchain_image_index);
+    // If the shouldRender flag is set, start rendering
+    if xr_context.frame_state.should_render {
+        render_context.begin_frame(&vulkan_context, available_swapchain_image_index);
+    } else {
+        println!(
+            "[HOTHAM_BEGIN_FRAME] - Session is runing but shouldRender is false - not rendering"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/hotham/src/schedule_functions/begin_pbr_renderpass.rs
+++ b/hotham/src/schedule_functions/begin_pbr_renderpass.rs
@@ -10,6 +10,14 @@ pub fn begin_pbr_renderpass(_world: &mut World, resources: &mut Resources) {
     let current_swapchain_image_index = resources.get_mut::<usize>().unwrap();
     let vulkan_context = resources.get::<VulkanContext>().unwrap();
 
+    // Check if we should be rendering.
+    if !xr_context.frame_state.should_render {
+        println!(
+            "[HOTHAM_BEGIN_PBR_RENDERPASS] - Session is runing but shouldRender is false - not rendering"
+        );
+        return;
+    }
+
     // If we have a valid view from OpenXR, update the scene buffers with the view data.
     if is_view_valid(&xr_context.view_state_flags) {
         let views = &xr_context.views;

--- a/hotham/src/schedule_functions/end_frame.rs
+++ b/hotham/src/schedule_functions/end_frame.rs
@@ -8,7 +8,14 @@ pub fn end_frame(_world: &mut World, resources: &mut Resources) {
     let current_swapchain_image_index = resources.get_mut::<usize>().unwrap();
     let vulkan_context = resources.get::<VulkanContext>().unwrap();
 
-    render_context.end_frame(&vulkan_context, *current_swapchain_image_index);
+    // Check if we should be rendering.
+    if xr_context.frame_state.should_render {
+        render_context.end_frame(&vulkan_context, *current_swapchain_image_index);
+    } else {
+        println!(
+            "[HOTHAM_END_FRAME] - Session is runing but shouldRender is false - not rendering"
+        );
+    }
     xr_context.end_frame().unwrap();
 }
 

--- a/hotham/src/schedule_functions/end_pbr_renderpass.rs
+++ b/hotham/src/schedule_functions/end_pbr_renderpass.rs
@@ -1,8 +1,21 @@
-use crate::{resources::RenderContext, resources::VulkanContext};
+use crate::{
+    resources::RenderContext,
+    resources::{VulkanContext, XrContext},
+};
 use legion::{Resources, World};
 pub fn end_pbr_renderpass(_world: &mut World, resources: &mut Resources) {
     // Get resources
     let mut render_context = resources.get_mut::<RenderContext>().unwrap();
+    let xr_context = resources.get_mut::<XrContext>().unwrap();
+
+    // Check if we should be rendering.
+    if !xr_context.frame_state.should_render {
+        println!(
+            "[HOTHAM_END_PBR_RENDERPASS] - Session is runing but shouldRender is false - not rendering"
+        );
+        return;
+    }
+
     let current_swapchain_image_index = resources.get_mut::<usize>().unwrap();
     let vulkan_context = resources.get::<VulkanContext>().unwrap();
     render_context.end_pbr_render_pass(&vulkan_context, *current_swapchain_image_index);


### PR DESCRIPTION
Implement the Android and OpenXR lifecycle correctly:

1. Don't render unless `shouldRender` is true.
2. When receiving the state `STOPPING`, end the session.
3. When moving from `EXITING` to `IDLE` don't sleep so that the runtime can kill us quickly.
4. Call `native_activity().finish()` when `App` is dropped

Fixes #84