### PR TITLE
Moved run_on_device scripts to new scripts directory

### DIFF
--- a/examples/crab-saber/scripts/run_on_device.ps1
+++ b/examples/crab-saber/scripts/run_on_device.ps1
@@ -1,6 +1,6 @@
 adb shell am force-stop rust.crab_saber
 
-Set-Location examples\crab-saber
+Set-Location $PSScriptRoot\..
 cargo apk run --release
 
 if ($?) {

--- a/examples/crab-saber/scripts/run_on_device.sh
+++ b/examples/crab-saber/scripts/run_on_device.sh
@@ -3,7 +3,9 @@ set -eux
 
 adb shell am force-stop rust.crab_saber
 
-cd examples/crab-saber
+scriptdir=$(dirname -- "$(realpath -- "$0")")
+cd $scriptdir/..
+
 cargo apk run --release
 
 adb logcat --pid="$(adb shell pidof rust.crab_saber)"


### PR DESCRIPTION
Fixes #153

Need someone to confirm/correct the relative directory structure the power shell script on windows? I believe PowerShell has $PSScriptRoot so just used $PSScriptRoot\..

Modified scripts to use correct directory relative to 'crab-saber/'