### PR TITLE
Fix simulator on Linux (#157)

### DIFF
--- a/hotham-simulator/src/lib.rs
+++ b/hotham-simulator/src/lib.rs
@@ -1,28 +1,28 @@
-#[cfg(target_os = "windows")]
+// #[cfg(target_os = "windows")]
 pub mod openxr_loader;
-#[cfg(target_os = "windows")]
+// #[cfg(target_os = "windows")]
 pub mod simulator;
-#[cfg(target_os = "windows")]
+// #[cfg(target_os = "windows")]
 pub mod space_state;
-#[cfg(target_os = "windows")]
+// #[cfg(target_os = "windows")]
 pub mod state;
 
-#[cfg(target_os = "windows")]
+// #[cfg(target_os = "windows")]
 use crate::openxr_loader::{
     PFN_xrEnumerateInstanceExtensionProperties, PFN_xrGetInstanceProcAddr, PFN_xrVoidFunction,
     XrInstance_T, XrResult,
 };
-#[cfg(target_os = "windows")]
+// #[cfg(target_os = "windows")]
 use crate::simulator::*;
 
-#[cfg(target_os = "windows")]
+// #[cfg(target_os = "windows")]
 use openxr_sys::{pfn, Result};
 
-#[cfg(target_os = "windows")]
+// #[cfg(target_os = "windows")]
 type DummyFn = unsafe extern "system" fn() -> Result;
 
 #[no_mangle]
-#[cfg(target_os = "windows")]
+// #[cfg(target_os = "windows")]
 pub unsafe extern "C" fn get_instance_proc_addr(
     _instance: *mut XrInstance_T,
     name: *const i8,
@@ -156,12 +156,12 @@ pub unsafe extern "C" fn get_instance_proc_addr(
     Result::SUCCESS.into_raw()
 }
 
-#[cfg(target_os = "windows")]
+// #[cfg(target_os = "windows")]
 static GET_INSTANCE_PROC_ADDR: PFN_xrGetInstanceProcAddr = Some(get_instance_proc_addr);
 
 #[allow(non_snake_case)]
 #[no_mangle]
-#[cfg(target_os = "windows")]
+// #[cfg(target_os = "windows")]
 pub unsafe extern "system" fn xrNegotiateLoaderRuntimeInterface(
     _loader_info: *const openxr_loader::XrNegotiateLoaderInfo,
     runtime_request: *mut openxr_loader::XrNegotiateRuntimeRequest,

--- a/hotham-simulator/src/simulator.rs
+++ b/hotham-simulator/src/simulator.rs
@@ -47,17 +47,20 @@ use std::{
 };
 use winit::event::{DeviceEvent, VirtualKeyCode};
 
-#[cfg(target_os = "windows")]
+// #[cfg(target_os = "windows")]
 use winit::{
     dpi::PhysicalSize,
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
-    platform::{
-        run_return::EventLoopExtRunReturn,
-        windows::{EventLoopExtWindows, WindowBuilderExtWindows},
-    },
+    platform::run_return::EventLoopExtRunReturn,
     window::WindowBuilder,
 };
+
+#[cfg(target_os = "windows")]
+use winit::platform::windows::{EventLoopExtWindows, WindowBuilderExtWindows};
+
+#[cfg(target_os = "linux")]
+use winit::platform::unix::EventLoopExtUnix;
 
 static SWAPCHAIN_COLOUR_FORMAT: vk::Format = vk::Format::B8G8R8A8_SRGB;
 pub const NUM_VIEWS: usize = 2; // TODO: Make dynamic
@@ -121,7 +124,7 @@ pub unsafe extern "system" fn create_instance(
     Result::SUCCESS
 }
 
-#[cfg(target_os = "windows")]
+// #[cfg(target_os = "windows")]
 pub unsafe extern "system" fn create_vulkan_instance(
     _instance: Instance,
     create_info: *const VulkanInstanceCreateInfoKHR,
@@ -138,7 +141,7 @@ pub unsafe extern "system" fn create_vulkan_instance(
 
     let event_loop: EventLoop<()> = EventLoop::new_any_thread();
     let window = WindowBuilder::new()
-        .with_drag_and_drop(false)
+        // .with_drag_and_drop(false)
         .with_visible(false)
         .build(&event_loop)
         .unwrap();
@@ -342,7 +345,7 @@ pub unsafe extern "system" fn get_vulkan_graphics_requirements(
     Result::SUCCESS
 }
 
-#[cfg(target_os = "windows")]
+// #[cfg(target_os = "windows")]
 pub unsafe extern "system" fn get_instance_properties(
     _instance: Instance,
     instance_properties: *mut InstanceProperties,
@@ -982,7 +985,7 @@ pub unsafe extern "system" fn enumerate_view_configuration_views(
     Result::SUCCESS
 }
 
-#[cfg(target_os = "windows")]
+// #[cfg(target_os = "windows")]
 pub unsafe extern "system" fn create_xr_swapchain(
     _session: Session,
     create_info: *const SwapchainCreateInfo,
@@ -1041,7 +1044,7 @@ fn create_multiview_image_views(
         .collect::<Vec<_>>()
 }
 
-#[cfg(target_os = "windows")]
+// #[cfg(target_os = "windows")]
 unsafe fn build_swapchain(state: &mut MutexGuard<State>) -> vk::SwapchainKHR {
     let entry = state.vulkan_entry.as_ref().unwrap().clone();
     let instance = state.vulkan_instance.as_ref().unwrap().clone();
@@ -1064,7 +1067,7 @@ unsafe fn build_swapchain(state: &mut MutexGuard<State>) -> vk::SwapchainKHR {
             .with_inner_size(PhysicalSize::new(VIEWPORT_WIDTH, VIEWPORT_HEIGHT))
             .with_title("Hotham Simulator")
             .with_visible(visible)
-            .with_drag_and_drop(false)
+            // .with_drag_and_drop(false)
             .build(&event_loop)
             .unwrap();
         println!("WINDOW SCALE FACTOR, {:?}", window.scale_factor());
@@ -1776,7 +1779,7 @@ pub unsafe extern "system" fn get_vulkan_instance_extensions(
 ) -> Result {
     let event_loop: EventLoop<()> = EventLoop::new_any_thread();
     let window = WindowBuilder::new()
-        .with_drag_and_drop(false)
+        // .with_drag_and_drop(false)
         .with_visible(false)
         .build(&event_loop)
         .unwrap();


### PR DESCRIPTION
This is a very rough draft PR, with (hopefully) most of the legwork to getting the simulator running on linux.

See #157 

This will need a proper look by @kanerogers, as I just straight up ripped the windows directives out (commented them rather), and removed some function calls that were no longer being found (.with_drag_and_drop(false)). I haven't properly looked at the code to see if it needs #windows, or not.