### PR TITLE
Implement a `Engine::run` method

### DIFF
--- a/examples/crab-saber/src/lib.rs
+++ b/examples/crab-saber/src/lib.rs
@@ -37,19 +37,17 @@ pub fn real_main() -> HothamResult<()> {
     let mut hotham_queries = Default::default();
     let mut crab_saber_queries = Default::default();
 
-    while let Ok((previous_state, current_state)) = engine.update() {
+    engine.run(|engine, previous_state, current_state| {
         tick(
             previous_state,
             current_state,
-            &mut engine,
+            engine,
             &mut world,
             &mut hotham_queries,
             &mut crab_saber_queries,
             &mut game_context,
-        );
-    }
-
-    Ok(())
+        )
+    })
 }
 
 fn tick(

--- a/examples/simple-scene/src/lib.rs
+++ b/examples/simple-scene/src/lib.rs
@@ -28,11 +28,7 @@ pub fn real_main() -> HothamResult<()> {
     let mut world = init(&mut engine)?;
     let mut queries = Default::default();
 
-    while let Ok((_, _)) = engine.update() {
-        tick(&mut engine, &mut world, &mut queries);
-    }
-
-    Ok(())
+    engine.run(|engine, _, _| tick(engine, &mut world, &mut queries))
 }
 
 fn init(engine: &mut Engine) -> Result<World, hotham::HothamError> {


### PR DESCRIPTION
**Draft: needs more doc, tests, maybe a trait.**
Implement a `Engine::run` method
Make `Engine::update` private

This makes the `Engine` a bit more foolproof, preventing anyone from forgetting to call `Engine::update`.
