### PR TITLE
Allow customization of OpenXR application name, version, required layers.

### DIFF
--- a/hotham/src/engine.rs
+++ b/hotham/src/engine.rs
@@ -25,34 +25,18 @@ pub static ANDROID_LOOPER_NONBLOCKING_TIMEOUT: Duration = Duration::from_millis(
 #[cfg(target_os = "android")]
 pub static ANDROID_LOOPER_BLOCKING_TIMEOUT: Duration = Duration::from_millis(i32::MAX as _);
 
-/// The Hotham Engine
-/// A wrapper around the "external world" from the perspective of the engine, eg. renderer, XR, etc.
-/// **IMPORTANT**: make sure you call `update` each tick
-pub struct Engine {
-    should_quit: Arc<AtomicBool>,
-    #[allow(dead_code)]
-    resumed: bool,
-    event_data_buffer: EventDataBuffer,
-    /// OpenXR context
-    pub xr_context: XrContext,
-    /// Vulkan context
-    pub vulkan_context: VulkanContext,
-    /// Renderer context
-    pub render_context: RenderContext,
-    /// Physics context
-    pub physics_context: PhysicsContext,
-    /// Audio context
-    pub audio_context: AudioContext,
-    /// GUI context
-    pub gui_context: GuiContext,
-    /// Haptics context
-    pub haptic_context: HapticContext,
-}
+/// Builder for `Engine`.
+#[derive(Default)]
+pub struct EngineBuilder {}
 
-impl Engine {
-    /// Create a new instance of the engine
-    /// NOTE: only one instance may be running at any one time
+impl EngineBuilder {
+    /// Create an `EngineBuilder`
     pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Build the `Engine`
+    pub fn build(self) -> Engine {
         #[allow(unused_mut)] // Only Android mutates this.
         let mut resumed = false;
         let should_quit = Arc::new(AtomicBool::from(false));
@@ -75,10 +59,11 @@ impl Engine {
             .expect("!!FATAL ERROR - Unable to initialise renderer!");
         let gui_context = GuiContext::new(&vulkan_context);
 
-        let mut engine = Self {
+        let mut engine = Engine {
             should_quit,
             resumed,
             event_data_buffer: Default::default(),
+
             xr_context,
             vulkan_context,
             render_context,
@@ -90,6 +75,39 @@ impl Engine {
 
         engine.update().unwrap();
         engine
+    }
+}
+
+/// The Hotham Engine
+/// A wrapper around the "external world" from the perspective of the engine, eg. renderer, XR, etc.
+/// **IMPORTANT**: make sure you call `update` each tick
+pub struct Engine {
+    should_quit: Arc<AtomicBool>,
+    #[allow(dead_code)]
+    resumed: bool,
+    event_data_buffer: EventDataBuffer,
+
+    /// OpenXR context
+    pub xr_context: XrContext,
+    /// Vulkan context
+    pub vulkan_context: VulkanContext,
+    /// Renderer context
+    pub render_context: RenderContext,
+    /// Physics context
+    pub physics_context: PhysicsContext,
+    /// Audio context
+    pub audio_context: AudioContext,
+    /// GUI context
+    pub gui_context: GuiContext,
+    /// Haptics context
+    pub haptic_context: HapticContext,
+}
+
+impl Engine {
+    /// Create a new instance of the engine
+    /// NOTE: only one instance may be running at any one time
+    pub fn new() -> Self {
+        EngineBuilder::new().build()
     }
 
     /// IMPORTANT: Call this function each tick to update the engine's running state with the underlying OS

--- a/hotham/src/engine.rs
+++ b/hotham/src/engine.rs
@@ -30,6 +30,7 @@ pub static ANDROID_LOOPER_BLOCKING_TIMEOUT: Duration = Duration::from_millis(i32
 pub struct EngineBuilder<'a> {
     application_name: Option<&'a str>,
     application_version: Option<u32>,
+    openxr_extensions: Option<xr::ExtensionSet>,
 }
 
 impl<'a> EngineBuilder<'a> {
@@ -47,6 +48,12 @@ impl<'a> EngineBuilder<'a> {
     /// Set the OpenXR application version
     pub fn application_version(&mut self, version: Option<u32>) -> &mut Self {
         self.application_version = version;
+        self
+    }
+
+    /// Set the required OpenXR extensions
+    pub fn openxr_extensions(&mut self, extensions: Option<xr::ExtensionSet>) -> &mut Self {
+        self.openxr_extensions = extensions;
         self
     }
 
@@ -71,6 +78,7 @@ impl<'a> EngineBuilder<'a> {
         let (xr_context, vulkan_context) = XrContextBuilder::new()
             .application_name(self.application_name)
             .application_version(self.application_version)
+            .required_extensions(self.openxr_extensions)
             .build()
             .expect("!!FATAL ERROR - Unable to initialise OpenXR!!");
         let render_context = RenderContext::new(&vulkan_context, &xr_context)

--- a/hotham/src/engine.rs
+++ b/hotham/src/engine.rs
@@ -1,7 +1,7 @@
 use crate::{
     resources::{
         AudioContext, GuiContext, HapticContext, PhysicsContext, RenderContext, VulkanContext,
-        XrContext,
+        XrContext, XrContextBuilder,
     },
     HothamError, HothamResult, VIEW_TYPE,
 };
@@ -27,12 +27,27 @@ pub static ANDROID_LOOPER_BLOCKING_TIMEOUT: Duration = Duration::from_millis(i32
 
 /// Builder for `Engine`.
 #[derive(Default)]
-pub struct EngineBuilder {}
+pub struct EngineBuilder<'a> {
+    application_name: Option<&'a str>,
+    application_version: Option<u32>,
+}
 
-impl EngineBuilder {
+impl<'a> EngineBuilder<'a> {
     /// Create an `EngineBuilder`
     pub fn new() -> Self {
         Default::default()
+    }
+
+    /// Set the OpenXR application name
+    pub fn application_name(&mut self, name: Option<&'a str>) -> &mut Self {
+        self.application_name = name;
+        self
+    }
+
+    /// Set the OpenXR application version
+    pub fn application_version(&mut self, version: Option<u32>) -> &mut Self {
+        self.application_version = version;
+        self
     }
 
     /// Build the `Engine`
@@ -53,8 +68,11 @@ impl EngineBuilder {
         }
 
         // Now initialise the engine.
-        let (xr_context, vulkan_context) =
-            XrContext::new().expect("!!FATAL ERROR - Unable to initialise OpenXR!!");
+        let (xr_context, vulkan_context) = XrContextBuilder::new()
+            .application_name(self.application_name)
+            .application_version(self.application_version)
+            .build()
+            .expect("!!FATAL ERROR - Unable to initialise OpenXR!!");
         let render_context = RenderContext::new(&vulkan_context, &xr_context)
             .expect("!!FATAL ERROR - Unable to initialise renderer!");
         let gui_context = GuiContext::new(&vulkan_context);

--- a/hotham/src/lib.rs
+++ b/hotham/src/lib.rs
@@ -15,7 +15,7 @@
 pub use ash::vk;
 pub use openxr as xr;
 
-pub use engine::Engine;
+pub use engine::{Engine, EngineBuilder};
 pub use hecs;
 pub use hotham_error::HothamError;
 pub use nalgebra;

--- a/hotham/src/resources/mod.rs
+++ b/hotham/src/resources/mod.rs
@@ -13,4 +13,4 @@ pub use haptic_context::HapticContext;
 pub use physics_context::PhysicsContext;
 pub use render_context::RenderContext;
 pub(crate) use vulkan_context::VulkanContext;
-pub use xr_context::XrContext;
+pub use xr_context::{XrContext, XrContextBuilder};

--- a/hotham/src/resources/vulkan_context.rs
+++ b/hotham/src/resources/vulkan_context.rs
@@ -72,10 +72,13 @@ impl VulkanContext {
             unsafe { std::mem::transmute(entry.static_fn().get_instance_proc_addr) };
 
         let app_name = CString::new(application_name)?;
+        let engine_name = CString::new("Hotham")?;
         let app_info = vk::ApplicationInfo::builder()
             .api_version(vk::make_api_version(0, 1, 2, 0))
             .application_name(&app_name)
             .application_version(application_version)
+            .engine_name(&engine_name)
+            .engine_version(1)
             .build();
 
         let create_info = vk::InstanceCreateInfo::builder().application_info(&app_info);
@@ -1141,9 +1144,12 @@ fn vulkan_init_legacy(
             .collect::<Vec<_>>();
 
         let app_name = CString::new(application_name)?;
+        let engine_name = CString::new("Hotham")?;
         let app_info = vk::ApplicationInfo::builder()
             .application_name(&app_name)
             .application_version(application_version)
+            .engine_name(&engine_name)
+            .engine_version(1)
             .api_version(vk::make_api_version(0, 1, 2, 0));
 
         let validation_features_enables = [];

--- a/hotham/src/resources/xr_context.rs
+++ b/hotham/src/resources/xr_context.rs
@@ -16,6 +16,7 @@ pub struct XrContextBuilder<'a> {
     path: Option<&'a std::path::Path>,
     application_name: Option<&'a str>,
     application_version: Option<u32>,
+    required_extensions: Option<xr::ExtensionSet>,
 }
 
 impl<'a> XrContextBuilder<'a> {
@@ -38,9 +39,18 @@ impl<'a> XrContextBuilder<'a> {
         self
     }
 
+    pub fn required_extensions(&mut self, extensions: Option<xr::ExtensionSet>) -> &mut Self {
+        self.required_extensions = extensions;
+        self
+    }
+
     pub fn build(&mut self) -> Result<(XrContext, VulkanContext)> {
-        let (instance, system) =
-            create_xr_instance(self.path, self.application_name, self.application_version)?;
+        let (instance, system) = create_xr_instance(
+            self.path,
+            self.application_name,
+            self.application_version,
+            self.required_extensions.as_ref(),
+        )?;
         XrContext::_new(instance, system)
     }
 }
@@ -390,6 +400,7 @@ pub(crate) fn create_xr_instance(
     path: Option<&std::path::Path>,
     application_name: Option<&str>,
     application_version: Option<u32>,
+    required_extensions: Option<&xr::ExtensionSet>,
 ) -> anyhow::Result<(xr::Instance, xr::SystemId)> {
     let xr_entry = if let Some(path) = path {
         xr::Entry::load_from(path)?
@@ -402,7 +413,7 @@ pub(crate) fn create_xr_instance(
         engine_name: "Hotham",
         engine_version: 1,
     };
-    let mut required_extensions = xr::ExtensionSet::default();
+    let mut required_extensions = required_extensions.cloned().unwrap_or_default();
     // required_extensions.khr_vulkan_enable2 = true; // TODO: Should we use enable 2 for the simulator..?
     required_extensions.khr_vulkan_enable = true; // TODO: Should we use enable 2 for the simulator..?
 

--- a/hotham/src/resources/xr_context.rs
+++ b/hotham/src/resources/xr_context.rs
@@ -11,6 +11,27 @@ use xr::{
 
 use crate::{resources::VulkanContext, BLEND_MODE, COLOR_FORMAT, VIEW_COUNT, VIEW_TYPE};
 
+#[derive(Default)]
+pub struct XrContextBuilder<'a> {
+    path: Option<&'a std::path::Path>,
+}
+
+impl<'a> XrContextBuilder<'a> {
+    pub fn new() -> Self {
+        XrContextBuilder::default()
+    }
+
+    pub fn path(&mut self, path: Option<&'a std::path::Path>) -> &mut Self {
+        self.path = path;
+        self
+    }
+
+    pub fn build(&mut self) -> Result<(XrContext, VulkanContext)> {
+        let (instance, system) = create_xr_instance(self.path)?;
+        XrContext::_new(instance, system)
+    }
+}
+
 pub struct XrContext {
     pub instance: openxr::Instance,
     pub session: Session<Vulkan>,
@@ -39,13 +60,11 @@ pub struct XrContext {
 
 impl XrContext {
     pub fn new() -> Result<(XrContext, VulkanContext)> {
-        let (instance, system) = create_xr_instance(None)?;
-        XrContext::_new(instance, system)
+        XrContextBuilder::new().build()
     }
 
     pub fn new_from_path(path: &std::path::Path) -> Result<(XrContext, VulkanContext)> {
-        let (instance, system) = create_xr_instance(Some(path))?;
-        XrContext::_new(instance, system)
+        XrContextBuilder::new().path(Some(path)).build()
     }
 
     fn _new(instance: xr::Instance, system: xr::SystemId) -> Result<(XrContext, VulkanContext)> {

--- a/hotham/src/resources/xr_context.rs
+++ b/hotham/src/resources/xr_context.rs
@@ -39,12 +39,12 @@ pub struct XrContext {
 
 impl XrContext {
     pub fn new() -> Result<(XrContext, VulkanContext)> {
-        let (instance, system) = create_xr_instance()?;
+        let (instance, system) = create_xr_instance(None)?;
         XrContext::_new(instance, system)
     }
 
     pub fn new_from_path(path: &std::path::Path) -> Result<(XrContext, VulkanContext)> {
-        let (instance, system) = create_xr_instance_from_path(path)?;
+        let (instance, system) = create_xr_instance(Some(path))?;
         XrContext::_new(instance, system)
     }
 
@@ -354,38 +354,14 @@ pub(crate) fn create_xr_session(
     .unwrap())
 }
 
-pub(crate) fn create_xr_instance() -> anyhow::Result<(xr::Instance, xr::SystemId)> {
-    let xr_entry = xr::Entry::load()?;
-    let xr_app_info = openxr::ApplicationInfo {
-        application_name: "Hotham Asteroid",
-        application_version: 1,
-        engine_name: "Hotham",
-        engine_version: 1,
-    };
-    let mut required_extensions = xr::ExtensionSet::default();
-    // required_extensions.khr_vulkan_enable2 = true; // TODO: Should we use enable 2 for the simulator..?
-    required_extensions.khr_vulkan_enable = true; // TODO: Should we use enable 2 for the simulator..?
-
-    #[cfg(target_os = "android")]
-    {
-        required_extensions.khr_android_create_instance = true;
-        xr_entry.initialize_android_loader()?;
-    }
-
-    println!(
-        "Available extensions: {:?}",
-        xr_entry.enumerate_extensions()?
-    );
-
-    let instance = xr_entry.create_instance(&xr_app_info, &required_extensions, &[])?;
-    let system = instance.system(xr::FormFactor::HEAD_MOUNTED_DISPLAY)?;
-    Ok((instance, system))
-}
-
-pub(crate) fn create_xr_instance_from_path(
-    path: &std::path::Path,
+pub(crate) fn create_xr_instance(
+    path: Option<&std::path::Path>,
 ) -> anyhow::Result<(xr::Instance, xr::SystemId)> {
-    let xr_entry = xr::Entry::load_from(path)?;
+    let xr_entry = if let Some(path) = path {
+        xr::Entry::load_from(path)?
+    } else {
+        xr::Entry::load()?
+    };
     let xr_app_info = openxr::ApplicationInfo {
         application_name: "Hotham Asteroid",
         application_version: 1,

--- a/hotham/src/resources/xr_context.rs
+++ b/hotham/src/resources/xr_context.rs
@@ -14,6 +14,8 @@ use crate::{resources::VulkanContext, BLEND_MODE, COLOR_FORMAT, VIEW_COUNT, VIEW
 #[derive(Default)]
 pub struct XrContextBuilder<'a> {
     path: Option<&'a std::path::Path>,
+    application_name: Option<&'a str>,
+    application_version: Option<u32>,
 }
 
 impl<'a> XrContextBuilder<'a> {
@@ -26,8 +28,19 @@ impl<'a> XrContextBuilder<'a> {
         self
     }
 
+    pub fn application_name(&mut self, name: Option<&'a str>) -> &mut Self {
+        self.application_name = name;
+        self
+    }
+
+    pub fn application_version(&mut self, version: Option<u32>) -> &mut Self {
+        self.application_version = version;
+        self
+    }
+
     pub fn build(&mut self) -> Result<(XrContext, VulkanContext)> {
-        let (instance, system) = create_xr_instance(self.path)?;
+        let (instance, system) =
+            create_xr_instance(self.path, self.application_name, self.application_version)?;
         XrContext::_new(instance, system)
     }
 }
@@ -375,6 +388,8 @@ pub(crate) fn create_xr_session(
 
 pub(crate) fn create_xr_instance(
     path: Option<&std::path::Path>,
+    application_name: Option<&str>,
+    application_version: Option<u32>,
 ) -> anyhow::Result<(xr::Instance, xr::SystemId)> {
     let xr_entry = if let Some(path) = path {
         xr::Entry::load_from(path)?
@@ -382,8 +397,8 @@ pub(crate) fn create_xr_instance(
         xr::Entry::load()?
     };
     let xr_app_info = openxr::ApplicationInfo {
-        application_name: "Hotham Asteroid",
-        application_version: 1,
+        application_name: application_name.unwrap_or("Hotham Asteroid"),
+        application_version: application_version.unwrap_or(1),
         engine_name: "Hotham",
         engine_version: 1,
     };


### PR DESCRIPTION
Make it so that applications can configure a bunch of OpenXR stuff by adding an EngineBuilder and XrContextBuilder to plumb things down to.

While we're at it, fix the android build, and make the ndk/ndk-glue versioning less restrictive so that top of tree openxr works.