### PR TITLE
Require a newer version of ndk-glue.

### DIFF
--- a/examples/crab-saber/Cargo.toml
+++ b/examples/crab-saber/Cargo.toml
@@ -19,7 +19,7 @@ rand = "0.8.0"
 approx = "0.5"
 
 [target.'cfg(target_os = "android")'.dependencies]
-ndk-glue = "=0.6.0"
+ndk-glue = "0.6"
 
 [package.metadata.android]
 apk_label = "Crab Saber"

--- a/examples/simple-scene/Cargo.toml
+++ b/examples/simple-scene/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 hotham = {path = "../../hotham"}
 
 [target.'cfg(target_os = "android")'.dependencies]
-ndk-glue = "0.6.0"
+ndk-glue = "0.6"
 
 [package.metadata.android]
 apk_label = "Hotham Simple Scene Example"

--- a/hotham/Cargo.toml
+++ b/hotham/Cargo.toml
@@ -48,5 +48,5 @@ approx = "0.5"
 
 [target.'cfg(target_os = "android")'.dependencies]
 jni = "0.18.0"
-ndk = "=0.6.0"
-ndk-glue = "=0.6.0"
+ndk = "0.6"
+ndk-glue = ">=0.6.2"


### PR DESCRIPTION
ndk-glue 0.6.2 moves its global state into another crate, ndk-context,
and initializes it. Other crates are starting to move to depending on
ndk-context instead, e.g. cpal depending on oboe '0.4', which is
getting resolved to a newly released 0.4.6 which depends on ndk-context.
Since we pin ndk-glue to exactly version 0.6.0, we're getting the old
ndk-glue alongside ndk-context, which remains uninitialized, leading to
explosions.

Fixes #201.