### PR TITLE
Fix audio spatialization position and velocity

### DIFF
--- a/examples/crab-saber/src/systems/sabers.rs
+++ b/examples/crab-saber/src/systems/sabers.rs
@@ -46,7 +46,7 @@ pub fn sabers_system(
         };
 
         // Locate the hand in the space.
-        let space = space.locate(&xr_context.reference_space, time).unwrap();
+        let space = space.locate(&xr_context.stage_space, time).unwrap();
         if !is_space_valid(&space) {
             return;
         }

--- a/hotham/src/resources/xr_context.rs
+++ b/hotham/src/resources/xr_context.rs
@@ -62,7 +62,7 @@ pub struct XrContext {
     pub session: Session<Vulkan>,
     pub session_state: SessionState,
     pub swapchain: Swapchain<Vulkan>,
-    pub reference_space: Space,
+    pub stage_space: Space,
     pub action_set: ActionSet,
     pub pose_action: Action<Posef>,
     pub grab_action: Action<f32>,
@@ -102,7 +102,7 @@ impl XrContext {
             create_vulkan_context(&instance, system, application_name, application_version)?;
         let (session, frame_waiter, frame_stream) =
             create_xr_session(&instance, system, &vulkan_context)?;
-        let reference_space =
+        let stage_space =
             session.create_reference_space(ReferenceSpaceType::STAGE, xr::Posef::IDENTITY)?;
         let swapchain_resolution = get_swapchain_resolution(&instance, system)?;
         let swapchain = create_xr_swapchain(&session, &swapchain_resolution, VIEW_COUNT)?;
@@ -221,7 +221,7 @@ impl XrContext {
             session,
             session_state: SessionState::IDLE,
             swapchain,
-            reference_space,
+            stage_space,
             action_set,
             pose_action,
             trigger_action,
@@ -314,7 +314,7 @@ impl XrContext {
         ];
 
         let layer_projection = xr::CompositionLayerProjection::new()
-            .space(&self.reference_space)
+            .space(&self.stage_space)
             .views(&views);
 
         let layers = [&*layer_projection];

--- a/hotham/src/resources/xr_context.rs
+++ b/hotham/src/resources/xr_context.rs
@@ -63,6 +63,7 @@ pub struct XrContext {
     pub session_state: SessionState,
     pub swapchain: Swapchain<Vulkan>,
     pub stage_space: Space,
+    pub view_space: Space,
     pub action_set: ActionSet,
     pub pose_action: Action<Posef>,
     pub grab_action: Action<f32>,
@@ -104,6 +105,8 @@ impl XrContext {
             create_xr_session(&instance, system, &vulkan_context)?;
         let stage_space =
             session.create_reference_space(ReferenceSpaceType::STAGE, xr::Posef::IDENTITY)?;
+        let view_space =
+            session.create_reference_space(ReferenceSpaceType::VIEW, xr::Posef::IDENTITY)?;
         let swapchain_resolution = get_swapchain_resolution(&instance, system)?;
         let swapchain = create_xr_swapchain(&session, &swapchain_resolution, VIEW_COUNT)?;
 
@@ -222,6 +225,7 @@ impl XrContext {
             session_state: SessionState::IDLE,
             swapchain,
             stage_space,
+            view_space,
             action_set,
             pose_action,
             trigger_action,

--- a/hotham/src/schedule_functions/begin_frame.rs
+++ b/hotham/src/schedule_functions/begin_frame.rs
@@ -26,7 +26,7 @@ pub fn begin_frame(
         .locate_views(
             VIEW_TYPE,
             xr_context.frame_state.predicted_display_time,
-            &xr_context.reference_space,
+            &xr_context.stage_space,
         )
         .unwrap();
     xr_context.views = views;

--- a/hotham/src/systems/audio.rs
+++ b/hotham/src/systems/audio.rs
@@ -186,7 +186,7 @@ mod tests {
             .locate_views(
                 VIEW_TYPE,
                 xr_context.frame_state.predicted_display_time,
-                &xr_context.reference_space,
+                &xr_context.stage_space,
             )
             .unwrap();
         xr_context.views = views;

--- a/hotham/src/systems/audio.rs
+++ b/hotham/src/systems/audio.rs
@@ -1,10 +1,10 @@
 use hecs::{PreparedQuery, World};
-use nalgebra::{Isometry3, Point3};
+use nalgebra::{Point3, Vector3};
+use openxr::{SpaceLocationFlags, SpaceVelocityFlags};
 
 use crate::{
     components::{sound_emitter::SoundState, RigidBody, SoundEmitter},
     resources::{AudioContext, PhysicsContext, XrContext},
-    util::posef_to_isometry,
 };
 
 /// Audio system
@@ -18,32 +18,62 @@ pub fn audio_system(
     physics_context: &PhysicsContext,
     xr_context: &XrContext,
 ) {
-    for (_, (sound_emitter, rigid_body)) in query.query_mut(world) {
-        // First, where is the listener?
-        let stage_from_listener =
-            get_location_from_poses(xr_context.views[0].pose, xr_context.views[1].pose);
+    // First, where is the listener?
+    let (listener_position_in_stage, listener_velocity_in_stage) = xr_context
+        .view_space
+        .relate(
+            &xr_context.stage_space,
+            xr_context.frame_state.predicted_display_time, // TODO: Use "now" instead.
+        )
+        .unwrap();
 
+    if !listener_position_in_stage
+        .location_flags
+        .contains(SpaceLocationFlags::POSITION_VALID)
+    {
+        return;
+    }
+
+    if !listener_velocity_in_stage
+        .velocity_flags
+        .contains(SpaceVelocityFlags::LINEAR_VALID)
+    {
+        return;
+    }
+
+    let listener_position_in_stage: Vector3<_> =
+        mint::Vector3::from(listener_position_in_stage.pose.position).into();
+    let listener_velocity_in_stage: Vector3<_> =
+        mint::Vector3::from(listener_velocity_in_stage.linear_velocity).into();
+
+    for (_, (sound_emitter, rigid_body)) in query.query_mut(world) {
         // Get the position and velocity of the entity.
         let rigid_body = physics_context
             .rigid_bodies
             .get(rigid_body.handle)
             .expect("Unable to get RigidBody");
 
-        let velocity_in_stage = (*rigid_body.linvel()).into();
+        let source_position_in_stage: Point3<_> = (*rigid_body.translation()).into();
+        let source_velocity_in_stage: Vector3<_> = *rigid_body.linvel();
 
-        // Now transform the position of the entity w.r.t. the listener
-        let position_in_listener = stage_from_listener
-            .inverse_transform_point(&Point3::from(*rigid_body.translation()))
-            .into();
+        // Compute relative position and velocity
+        let relative_position_in_stage =
+            (source_position_in_stage - listener_position_in_stage).into();
+        let relative_velocity_in_stage =
+            (source_velocity_in_stage - listener_velocity_in_stage).into();
 
         // Determine what we should do with the audio source
         match (sound_emitter.current_state(), &sound_emitter.next_state) {
             (SoundState::Stopped, Some(SoundState::Playing)) => {
                 println!(
                     "[HOTHAM_AUDIO] - Playing sound effect at {:?}, {:?} from {:?}!. Original position: {:?}",
-                    position_in_listener, velocity_in_stage, stage_from_listener, rigid_body.translation()
+                    relative_position_in_stage, source_velocity_in_stage, listener_position_in_stage, rigid_body.translation()
                 );
-                audio_context.play_audio(sound_emitter, position_in_listener, velocity_in_stage);
+                audio_context.play_audio(
+                    sound_emitter,
+                    relative_position_in_stage,
+                    relative_velocity_in_stage,
+                );
             }
             (SoundState::Paused, Some(SoundState::Playing)) => {
                 audio_context.resume_audio(sound_emitter);
@@ -64,12 +94,12 @@ pub fn audio_system(
         sound_emitter.next_state = None;
 
         // Update its position and velocity
-        audio_context.update_motion(sound_emitter, position_in_listener, velocity_in_stage);
+        audio_context.update_motion(
+            sound_emitter,
+            relative_position_in_stage,
+            relative_velocity_in_stage,
+        );
     }
-}
-
-fn get_location_from_poses(left_eye: openxr::Posef, right_eye: openxr::Posef) -> Isometry3<f32> {
-    posef_to_isometry(left_eye).lerp_slerp(&posef_to_isometry(right_eye), 0.5)
 }
 
 #[cfg(target_os = "windows")]

--- a/hotham/src/systems/hands.rs
+++ b/hotham/src/systems/hands.rs
@@ -30,7 +30,7 @@ pub fn hands_system(
         };
 
         // Locate the hand in the space.
-        let space = space.locate(&xr_context.reference_space, time).unwrap();
+        let space = space.locate(&xr_context.stage_space, time).unwrap();
 
         // Check it's valid before using it
         if !is_space_valid(&space) {

--- a/hotham/src/systems/pointers.rs
+++ b/hotham/src/systems/pointers.rs
@@ -50,7 +50,7 @@ pub fn pointers_system(
         };
 
         // Locate the pointer in the space.
-        let space = space.locate(&xr_context.reference_space, time).unwrap();
+        let space = space.locate(&xr_context.stage_space, time).unwrap();
         if !is_space_valid(&space) {
             return;
         }


### PR DESCRIPTION
This PR introduces a naming convention for transforms and coordinates. Transforms are named `<space>_from_<space>` and positions are named `<thing>_in_<space>`, eg `point_in_stage = stage_from_hand * point_in_hand`. This makes it trivial to compose transforms and spot mistakes.

One such mistake was how positions and velocities were handled in `audio.rs`, the position and velocity were specified in different coordinate spaces and it turned out both were wrong. This PR fixes that by adding the OpenXR view space so that the relative position and velocity of the view and stage reference systems can be retrieved.

There is still some room for future improvements. Two things come to mind:
1. Apply an offset to the view space to move the listener closer to the ears instead of the eyes. This can be done by passing the offset instead of an identity pose to `create_reference_space`.
2.  Use a better time than `predicted_display_time`. There is a `xr_context.instance.now()` but it complained about _"KHR_win32_convert_performance_counter_time not loaded"_ when I tried it.

I have tested running crab saber with this PR on PCVR using Quest 2 + Windows 10 + oculus airlink. It would be great if someone would test this natively on Quest 2.