### PR TITLE
Fix hands don't move when only one controller is connected.

### DIFF
--- a/hotham/src/systems/hands.rs
+++ b/hotham/src/systems/hands.rs
@@ -34,7 +34,7 @@ pub fn hands_system(
 
         // Check it's valid before using it
         if !is_space_valid(&space) {
-            return;
+            continue;
         }
 
         let pose = space.pose;


### PR DESCRIPTION
Just skip hands with invalid spaces instead of returning early.

Fixes #179.