### PR TITLE
Allow asset importer to import models with no materials

### DIFF
--- a/hotham/src/asset_importer/mod.rs
+++ b/hotham/src/asset_importer/mod.rs
@@ -335,6 +335,8 @@ pub fn add_model_to_world(
     Some(new_root_entity)
 }
 
+// These tests are disabled for other platforms
+// https://github.com/leetvr/hotham/issues/240
 #[cfg(target_os = "windows")]
 #[cfg(test)]
 mod tests {
@@ -439,9 +441,7 @@ mod tests {
     #[test]
     fn test_load_model_with_no_material() {
         let (mut render_context, vulkan_context) = RenderContext::testing();
-        let data: Vec<&[u8]> = vec![
-            include_bytes!("../../../test_assets/box_no_material.glb"),
-        ];
+        let data: Vec<&[u8]> = vec![include_bytes!("../../../test_assets/box_no_material.glb")];
         let _models = load_models_from_glb(&data, &vulkan_context, &mut render_context).unwrap();
     }
 

--- a/hotham/src/asset_importer/mod.rs
+++ b/hotham/src/asset_importer/mod.rs
@@ -437,6 +437,15 @@ mod tests {
     }
 
     #[test]
+    fn test_load_model_with_no_material() {
+        let (mut render_context, vulkan_context) = RenderContext::testing();
+        let data: Vec<&[u8]> = vec![
+            include_bytes!("../../../test_assets/box_no_material.glb"),
+        ];
+        let _models = load_models_from_glb(&data, &vulkan_context, &mut render_context).unwrap();
+    }
+
+    #[test]
     pub fn test_hand() {
         let (mut render_context, vulkan_context) = RenderContext::testing();
 

--- a/hotham/src/rendering/material.rs
+++ b/hotham/src/rendering/material.rs
@@ -13,6 +13,9 @@ pub static SPECULAR_GLOSSINESS_WORKFLOW: u32 = 1;
 /// Tells the fragment shader to use the unlit workflow
 pub static UNLIT_WORKFLOW: u32 = 2;
 
+/// Material index into the default material
+pub static NO_MATERIAL: usize = 0;
+
 /// Mostly maps to the [glTF material spec](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#materials) and
 /// added by default by the `gltf_loader`
 #[repr(C, align(16))]

--- a/hotham/src/rendering/primitive.rs
+++ b/hotham/src/rendering/primitive.rs
@@ -1,5 +1,7 @@
 use crate::{
-    asset_importer::ImportContext, components::Transform, rendering::vertex::Vertex,
+    asset_importer::ImportContext,
+    components::Transform,
+    rendering::{material::NO_MATERIAL, vertex::Vertex},
     resources::render_context,
 };
 use itertools::izip;
@@ -125,11 +127,7 @@ impl Primitive {
         // All the materials in this glTF file will be imported into the material buffer, so all we need
         // to do is grab the index of this material and add it to the running offset. If we don't do this,
         // importing multiple glTF files will result in sadness, misery, and really ugly looking scenes.
-        let material_id = primitive_data
-            .material()
-            .index()
-            .expect("Primitives without materials are not yet supported!")
-            as u32
+        let material_id = primitive_data.material().index().unwrap_or(NO_MATERIAL) as u32
             + import_context.material_buffer_offset;
 
         Primitive::new(

--- a/hotham/src/rendering/resources.rs
+++ b/hotham/src/rendering/resources.rs
@@ -75,12 +75,14 @@ impl Resources {
         );
         draw_data_buffer.update_descriptor_set(&vulkan_context.device, descriptors.set, 0);
 
-        let materials_buffer = Buffer::new(
+        let mut materials_buffer = Buffer::new(
             vulkan_context,
             vk::BufferUsageFlags::STORAGE_BUFFER,
             MATERIAL_BUFFER_SIZE,
         );
         materials_buffer.update_descriptor_set(&vulkan_context.device, descriptors.set, 1);
+        // RESERVE index 0 for the default material, available as the material::NO_MATERIAL constant.
+        materials_buffer.push(&Material::default());
 
         let draw_indirect_buffer = Buffer::new(
             vulkan_context,

--- a/test_assets/box_no_material.glb
+++ b/test_assets/box_no_material.glb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e7039cb1d715d151bbb426bc8cee6b8abe7f127eb7dac764407b942a6c83a6f
+size 1720

--- a/test_assets/box_no_material.glb
+++ b/test_assets/box_no_material.glb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7e7039cb1d715d151bbb426bc8cee6b8abe7f127eb7dac764407b942a6c83a6f
-size 1720
+oid sha256:664d4544f9c287f76abe0408fc456d043f41c613fbacae795882ec7388dbe928
+size 1740


### PR DESCRIPTION
Reserve index 0 in the material buffer for the default material, and use that when there are no materials in the gltf file.

Fixes #241 