### PR TITLE
[Bug]: ASTC not supported on desktop, causes simulator to panic when importing ktx2 texture

### DIFF
--- a/benchmarks/stress-test/src/lib.rs
+++ b/benchmarks/stress-test/src/lib.rs
@@ -120,9 +120,13 @@ fn init(engine: &mut Engine, test: &StressTest) -> (World, HashMap<String, World
             models
         }
         StressTest::ManyHelmets => {
+            #[cfg(target_os = "android")]
             let glb_buffers: Vec<&[u8]> = vec![include_bytes!(
                 "../../../test_assets/damaged_helmet_squished.glb"
             )];
+            #[cfg(not(target_os = "android"))]
+            let glb_buffers: Vec<&[u8]> =
+                vec![include_bytes!("../../../test_assets/damaged_helmet.glb")];
             let models =
                 asset_importer::load_models_from_glb(&glb_buffers, vulkan_context, render_context)
                     .unwrap();

--- a/examples/simple-scene/src/lib.rs
+++ b/examples/simple-scene/src/lib.rs
@@ -40,11 +40,19 @@ fn init(engine: &mut Engine) -> Result<World, hotham::HothamError> {
     let physics_context = &mut engine.physics_context;
     let mut world = World::default();
 
-    let glb_buffers: Vec<&[u8]> = vec![
+    let mut glb_buffers: Vec<&[u8]> = vec![
         include_bytes!("../../../test_assets/left_hand.glb"),
         include_bytes!("../../../test_assets/right_hand.glb"),
-        include_bytes!("../../../test_assets/damaged_helmet_squished.glb"),
     ];
+
+    #[cfg(target_os = "android")]
+    glb_buffers.push(include_bytes!(
+        "../../../test_assets/damaged_helmet_squished.glb"
+    ));
+
+    #[cfg(not(target_os = "android"))]
+    glb_buffers.push(include_bytes!("../../../test_assets/damaged_helmet.glb"));
+
     let models =
         asset_importer::load_models_from_glb(&glb_buffers, vulkan_context, render_context)?;
     add_helmet(&models, &mut world, physics_context);


### PR DESCRIPTION
 ## What is this related to?
Fixes #251

## What changed?
Choose the right `glb` based on the target_os

## What is the overall impact?
We can now load assets when running on the simulator, but they look messed up. We'll handle this in #253