### PR TITLE
Kanerogers/issue253

### DIFF
--- a/hotham/Cargo.toml
+++ b/hotham/Cargo.toml
@@ -17,8 +17,7 @@ crossbeam = "0.8.1"
 ctrlc = {version = "3", features = ["termination"]}
 egui = "0.15"
 generational-arena = "0.2.8"
-# gltf = {version = "1.0", features = ["KHR_materials_pbrSpecularGlossiness"]}
-gltf = {git = "https://github.com/Gutawer/gltf", features = ["KHR_materials_pbrSpecularGlossiness", "KHR_texture_basisu"], rev = "e137db3"}
+gltf = {version = "1.0", features = ["KHR_materials_pbrSpecularGlossiness", "names", "utils"], default-features = false}
 hecs = "0.7.7"
 hotham-debug-server = {path = "../hotham-debug-server", version = "0.2"}
 id-arena = "2.2.1"

--- a/hotham/src/asset_importer/mod.rs
+++ b/hotham/src/asset_importer/mod.rs
@@ -87,11 +87,6 @@ fn load_models_from_gltf_data(import_context: &mut ImportContext) -> Result<()> 
         Material::load(material, import_context);
     }
 
-    // TODO: load textures independent from materials
-    // for texture in document.textures() {
-    //     Texture::load(texture, import_context);
-    // }
-
     // We need *some* entity to stash the AnimationController onto.
     // For now, just use the first root entity.
     let mut animation_controller_entity = None;
@@ -113,6 +108,7 @@ fn load_models_from_gltf_data(import_context: &mut ImportContext) -> Result<()> 
     }
 
     // Finally, import any skins or animations.
+    //
     // Note that this has to be done after every single node has been imported, as skins and animations can reference any other node.
 
     // Skins are attached to nodes, so we need to go back through the node tree.

--- a/hotham/src/rendering/texture.rs
+++ b/hotham/src/rendering/texture.rs
@@ -36,7 +36,7 @@ impl Texture {
         let image = vulkan_context
             .create_image(
                 format,
-                &extent,
+                extent,
                 vk::ImageUsageFlags::SAMPLED | vk::ImageUsageFlags::TRANSFER_DST,
                 1,
                 1,

--- a/hotham/src/rendering/texture.rs
+++ b/hotham/src/rendering/texture.rs
@@ -30,14 +30,13 @@ impl Texture {
         vulkan_context: &VulkanContext,
         render_context: &mut RenderContext,
         image_buf: &[u8],
-        width: u32,
-        height: u32,
+        extent: &vk::Extent2D,
         format: vk::Format,
     ) -> Self {
         let image = vulkan_context
             .create_image(
                 format,
-                &vk::Extent2D { width, height },
+                &extent,
                 vk::ImageUsageFlags::SAMPLED | vk::ImageUsageFlags::TRANSFER_DST,
                 1,
                 1,
@@ -55,72 +54,31 @@ impl Texture {
     pub(crate) fn load(texture: gltf::texture::Texture, import_context: &mut ImportContext) -> u32 {
         let texture_name = &format!("Texture {}", texture.name().unwrap_or(""));
 
-        // HACK
-        // This is a *hack*. We don't actually support basisu, we're just using the extension to smuggle pre-compressed ktx2 files
-        // into our GLB files. We do *eventually* want to support basisu, but we're both blocked on a couple of upstream crates
-        // and this may not be the optimal thing to do for performance reasons.
-        //
-        // See https://github.com/leetvr/hotham/issues/237 for more details.
-        if let (_, Some(basis_u)) = texture.basisu_sources() {
-            match basis_u.source() {
-                gltf::image::Source::View { view, .. } => {
-                    let start = view.offset();
-                    let end = start + view.length();
-                    let ktx2_data = &import_context.buffer[start..end];
-                    let ktx2_reader = ktx2::Reader::new(ktx2_data).unwrap();
-                    let header = ktx2_reader.header();
-                    if header.supercompression_scheme.is_some() {
-                        panic!("[HOTHAM_TEXTURE] ktx2 supercompression is currently unsupported");
-                    }
-
-                    // We don't really support mipmaps with Hotham yet. So, we assume there is ONLY ONE mipmap level.
-                    let image_bytes = ktx2_reader.levels().next().unwrap();
-                    let format = get_format_from_ktx2(header.format);
-                    println!(
-                        "[HOTHAM_TEXTURE] Importing ktx2 texture in {:?} format",
-                        format
-                    );
-                    let texture = Texture::new(
-                        "",
+        let texture = match texture.source().source() {
+            // HACK
+            // This is a *hack*. Storing ktx2 images in the source field without the KHR_texture_basisu extension
+            // is *not allowed*. But, such is life.
+            //
+            // See https://github.com/leetvr/hotham/issues/237 for more details.
+            gltf::image::Source::View { view, mime_type } => {
+                let start = view.offset();
+                let end = start + view.length();
+                let bytes = &import_context.buffer[start..end];
+                match mime_type {
+                    "image/ktx2" => Texture::from_ktx2(
+                        texture_name,
                         import_context.vulkan_context,
                         import_context.render_context,
-                        image_bytes,
-                        header.pixel_width,
-                        header.pixel_height,
-                        format,
-                    );
-                    return texture.index;
+                        bytes,
+                    ),
+                    _ => Texture::from_uncompressed(
+                        texture_name,
+                        mime_type,
+                        import_context.vulkan_context,
+                        import_context.render_context,
+                        bytes,
+                    ),
                 }
-
-                _ => panic!("Not supported"),
-            }
-        }
-
-        let texture = match texture.source().source() {
-            gltf::image::Source::View { view, mime_type } => {
-                println!("[HOTHAM_TEXTURE] - WARNING: Non-optimal image format detected. For best performance, compress your images into ktx2.");
-                print!("[HOTHAM_TEXTURE] - Decompresing image. This may take some time..");
-                let bytes = &import_context.buffer[view.offset()..view.buffer().length()];
-                let format = get_format_from_mime_type(mime_type);
-                let asset = Cursor::new(bytes);
-                let mut image = ImageReader::new(asset);
-                image.set_format(format);
-                let image = image.decode().expect("Unable to decompress image!");
-                let image = image.to_rgba8();
-                let width = image.width();
-                let height = image.height();
-
-                println!("..done!");
-
-                Texture::new(
-                    texture_name,
-                    import_context.vulkan_context,
-                    import_context.render_context,
-                    &image.into_raw(),
-                    width,
-                    height,
-                    TEXTURE_FORMAT,
-                )
             }
             _ => panic!(
                 "[HOTHAM_TEXTURE] - Unable to import image - URI references are not supported"
@@ -150,6 +108,83 @@ impl Texture {
             .unwrap();
 
         Texture { image, index }
+    }
+
+    /// Create a texture from a ktx2 container.
+    ///
+    /// This is the preferred way of using textures in Hotham. By compressing the image in a GPU friendly way we can drastically reduce the amount of
+    /// bandwidth used to sample from it.
+    pub fn from_ktx2(
+        name: &str,
+        vulkan_context: &VulkanContext,
+        render_context: &mut RenderContext,
+        ktx2_data: &[u8],
+    ) -> Self {
+        let ktx2_reader = ktx2::Reader::new(ktx2_data).unwrap();
+        let header = ktx2_reader.header();
+        if header.supercompression_scheme.is_some() {
+            panic!("[HOTHAM_TEXTURE] ktx2 supercompression is currently unsupported");
+        }
+
+        let extent = vk::Extent2D {
+            width: header.pixel_width,
+            height: header.pixel_height,
+        };
+        let format = get_format_from_ktx2(header.format);
+
+        // We don't really support mipmaps with Hotham yet. So, we assume there is ONLY ONE mipmap level.
+        let image_bytes = ktx2_reader.levels().next().unwrap();
+        println!(
+            "[HOTHAM_TEXTURE] Importing ktx2 texture in {:?} format",
+            format
+        );
+
+        Texture::new(
+            name,
+            vulkan_context,
+            render_context,
+            image_bytes,
+            &extent,
+            format,
+        )
+    }
+
+    /// Create a texture from an uncompressed image, like JPG or PNG.
+    ///
+    /// This is slow because we have to extract the image on the CPU before we can upload it to the GPU: hardly ideal. It is neccessary
+    /// when testing in the simulator because compressing images into desktop friendly formats like BCn would be overkill for testing.
+    pub fn from_uncompressed(
+        name: &str,
+        mime_type: &str,
+        vulkan_context: &VulkanContext,
+        render_context: &mut RenderContext,
+        data: &[u8],
+    ) -> Self {
+        #[cfg(not(target_os = "android"))]
+        println!("[HOTHAM_TEXTURE] - @@ WARNING: Non-optimal image format detected. For best performance, compress your images into ktx2 using Squisher: https://github.com/leetvr/squisher. @@");
+
+        print!("[HOTHAM_TEXTURE] - Decompresing image. This may take some time..");
+        let decompressed_format = get_format_from_mime_type(mime_type);
+        let asset = Cursor::new(data);
+        let mut image = ImageReader::new(asset);
+        image.set_format(decompressed_format);
+        let image = image.decode().expect("Unable to decompress image!");
+        let image = image.to_rgba8();
+        let extent = vk::Extent2D {
+            width: image.width(),
+            height: image.height(),
+        };
+
+        println!(" ..done!");
+
+        Texture::new(
+            name,
+            vulkan_context,
+            render_context,
+            &image.into_raw(),
+            &extent,
+            TEXTURE_FORMAT,
+        )
     }
 }
 

--- a/test_assets/damaged_helmet_squished.glb
+++ b/test_assets/damaged_helmet_squished.glb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a3e84c4e3069746197f2cbba7e581bacbaebf4016cce13cdd58328cc16270eb5
-size 5805616
+oid sha256:0bacb62d550abcfbacc72acdc09b34d766d3efd91bbcf5b97918301a1143ac30
+size 5805340


### PR DESCRIPTION
## What is this related to?
#253

## What changed?
We no longer use the KHR_texture_basisu extension to smuggle ktx2 files into our GLB assets.

## What is the overall impact?
We can correctly release the crate without depending on git dependencies.