### PR TITLE
Fix right_pointer_space

### DIFF
--- a/hotham/src/resources/xr_context/input.rs
+++ b/hotham/src/resources/xr_context/input.rs
@@ -179,7 +179,7 @@ impl Input {
             Posef::IDENTITY,
         )?;
         let right_pointer_space =
-            aim_action.create_space(session.clone(), left_hand_subaction_path, Posef::IDENTITY)?;
+            aim_action.create_space(session.clone(), right_hand_subaction_path, Posef::IDENTITY)?;
 
         Ok(Input {
             action_set,


### PR DESCRIPTION
Fix a typo that made `right_pointer_space` contain the left pointer instead of the right.