### PR TITLE
Fix swizzling on desktop

### DIFF
--- a/hotham/src/rendering/texture.rs
+++ b/hotham/src/rendering/texture.rs
@@ -244,7 +244,7 @@ fn get_component_mapping(
             r: vk::ComponentSwizzle::ZERO,
             g: vk::ComponentSwizzle::R,
             b: vk::ComponentSwizzle::ZERO,
-            a: vk::ComponentSwizzle::B,
+            a: vk::ComponentSwizzle::G,
         },
         (true, TextureUsage::MetallicRoughness) => vk::ComponentMapping {
             r: vk::ComponentSwizzle::ZERO,

--- a/hotham/src/shaders/pbr.frag
+++ b/hotham/src/shaders/pbr.frag
@@ -325,8 +325,7 @@ void main()
 				outColor.rgba = baseColor;
 				break;
 			case 2:
-				outColor.rg = (material.normalTextureID == NO_TEXTURE) ? normalize(inNormal).xy : texture(textures[material.normalTextureID], inUV).ga;
-				outColor.b = 0.0;
+				outColor.rgb = n * 0.5 + 0.5;
 				break;
 			case 3:
 				outColor.rgb = (material.occlusionTextureID == NO_TEXTURE) ? vec3(0.0f) : texture(textures[material.occlusionTextureID], inUV).ggg;


### PR DESCRIPTION
This resolves #277. It turns out the issue was trivial. The blue channel (`normal.z`) was passed to the shader instead of the green channel (`normal.y`). I also took the liberty of changing the render debug mode for normals to render the computed normal instead of `inNormal.xy` or raw texture.

### Normals before
![Screenshot 2022-07-23 153527](https://user-images.githubusercontent.com/1162652/180607441-535acd95-6305-4f58-b180-332edb6865ce.png)

### Normals after
![Screenshot 2022-07-23 153610](https://user-images.githubusercontent.com/1162652/180607443-3f700ba7-6539-447f-b5ea-708e80cafcbd.png)

### Render before
![Screenshot 2022-07-23 154122](https://user-images.githubusercontent.com/1162652/180607585-ab10eebc-e872-43e5-9a7b-12ac51b72693.png)

### Render after
![Screenshot 2022-07-23 154044](https://user-images.githubusercontent.com/1162652/180607589-78c5bdeb-41f5-474b-9f7f-bb165aeb7486.png)

