### PR TITLE
Improve culling and simulator responsiveness

### DIFF
--- a/hotham-simulator/src/state.rs
+++ b/hotham-simulator/src/state.rs
@@ -297,6 +297,7 @@ impl State {
         // self.spaces.get_mut(&right_hand).unwrap().position.z += z_delta;
         // self.spaces.get_mut(&right_hand).unwrap().position.x += x_delta;
 
+        self.view_poses[1] = self.view_poses[0];
         Some(())
     }
 }

--- a/hotham-simulator/src/state.rs
+++ b/hotham-simulator/src/state.rs
@@ -218,7 +218,7 @@ impl State {
         let movement_speed = 2f32 * dt;
         let mouse_sensitivity = 4f32 * dt;
 
-        if let Ok(input_event) = self.event_rx.as_ref()?.try_recv() {
+        while let Ok(input_event) = self.event_rx.as_ref()?.try_recv() {
             match input_event {
                 DeviceEvent::Key(keyboard_input) => self.input_state.process_event(keyboard_input),
                 DeviceEvent::MouseMotion { delta: (x, y) } => {

--- a/hotham/src/resources/render_context.rs
+++ b/hotham/src/resources/render_context.rs
@@ -256,16 +256,12 @@ impl RenderContext {
             left_clip_planes: Matrix4::<_>::from_rows(&[
                 normalize_plane(left_frustum_from_world.row(3) + left_frustum_from_world.row(0)),
                 normalize_plane(left_frustum_from_world.row(3) - left_frustum_from_world.row(0)),
-                // normalize_plane(left_frustum_from_world.row(3) + left_frustum_from_world.row(1)),
-                // normalize_plane(left_frustum_from_world.row(3) - left_frustum_from_world.row(1)),
                 normalize_plane(left_frustum_from_world.row(3) + left_frustum_from_world.row(2)),
                 normalize_plane(left_frustum_from_world.row(3) - left_frustum_from_world.row(2)),
             ]),
             right_clip_planes: Matrix4::<_>::from_rows(&[
                 normalize_plane(right_frustum_from_world.row(3) + right_frustum_from_world.row(0)),
                 normalize_plane(right_frustum_from_world.row(3) - right_frustum_from_world.row(0)),
-                // normalize_plane(right_frustum_from_world.row(3) + right_frustum_from_world.row(1)),
-                // normalize_plane(right_frustum_from_world.row(3) - right_frustum_from_world.row(1)),
                 normalize_plane(right_frustum_from_world.row(3) + right_frustum_from_world.row(2)),
                 normalize_plane(right_frustum_from_world.row(3) - right_frustum_from_world.row(2)),
             ]),

--- a/hotham/src/resources/render_context.rs
+++ b/hotham/src/resources/render_context.rs
@@ -30,7 +30,7 @@ use crate::{
 };
 use anyhow::Result;
 use ash::vk::{self, Handle};
-use nalgebra::Matrix4;
+use nalgebra::{Matrix4, RowVector4};
 use openxr as xr;
 use vk_shader_macros::include_glsl;
 
@@ -229,26 +229,46 @@ impl RenderContext {
         let near = 0.05;
         let far = 100.0;
 
-        let fov_left = self.views[0].fov;
-        let fov_right = self.views[1].fov;
-        let fov = xr::Fovf {
-            angle_left: fov_left.angle_left,
-            angle_right: fov_right.angle_right,
-            angle_up: fov_left.angle_up,
-            angle_down: fov_left.angle_down,
-        };
-
-        // A virtual camera between the player's eyes
-        let frustum_projection = get_projection(fov, near, far);
-        let frustum_view = self.cameras[0]
+        // Compute left_frustum_from_world
+        let left_frustum_from_left_camera = get_projection(self.views[0].fov, near, far);
+        let left_camera_from_world = self.cameras[0]
             .position
-            .lerp_slerp(&self.cameras[1].position, 0.5)
             .to_homogeneous()
             .try_inverse()
             .unwrap();
+        let left_frustum_from_world = left_frustum_from_left_camera * left_camera_from_world;
 
+        // Compute right_frustum_from_world
+        let right_frustum_from_right_camera = get_projection(self.views[1].fov, near, far);
+        let right_camera_from_world = self.cameras[1]
+            .position
+            .to_homogeneous()
+            .try_inverse()
+            .unwrap();
+        let right_frustum_from_world = right_frustum_from_right_camera * right_camera_from_world;
+
+        // Normals of the clipping planes are pointing towards the inside of the frustum.
+        // We are only using four planes per camera. The near and far planes are not used.
+        // This link points to a paper describing the math behind these expressions:
+        // https://www.gamedevs.org/uploads/fast-extraction-viewing-frustum-planes-from-world-view-projection-matrix.pdf
+        let normalize_plane = |p: RowVector4<_>| p / p.columns(0, 3).norm();
         let cull_data = CullData {
-            frustum: frustum_projection * frustum_view,
+            clip_planes1: Matrix4::<_>::from_rows(&[
+                normalize_plane(left_frustum_from_world.row(3) + left_frustum_from_world.row(0)),
+                normalize_plane(left_frustum_from_world.row(3) - left_frustum_from_world.row(0)),
+                // normalize_plane(left_frustum_from_world.row(3) + left_frustum_from_world.row(1)),
+                // normalize_plane(left_frustum_from_world.row(3) - left_frustum_from_world.row(1)),
+                normalize_plane(left_frustum_from_world.row(3) + left_frustum_from_world.row(2)),
+                normalize_plane(left_frustum_from_world.row(3) - left_frustum_from_world.row(2)),
+            ]),
+            clip_planes2: Matrix4::<_>::from_rows(&[
+                normalize_plane(right_frustum_from_world.row(3) + right_frustum_from_world.row(0)),
+                normalize_plane(right_frustum_from_world.row(3) - right_frustum_from_world.row(0)),
+                // normalize_plane(right_frustum_from_world.row(3) + right_frustum_from_world.row(1)),
+                // normalize_plane(right_frustum_from_world.row(3) - right_frustum_from_world.row(1)),
+                normalize_plane(right_frustum_from_world.row(3) + right_frustum_from_world.row(2)),
+                normalize_plane(right_frustum_from_world.row(3) - right_frustum_from_world.row(2)),
+            ]),
             draw_calls: draw_indirect_buffer.len as u32,
         };
 
@@ -729,8 +749,9 @@ fn create_pipeline_layout(
 #[repr(C)]
 #[derive(Debug, Clone)]
 pub struct CullData {
-    /// View-Projection matrices (one per eye)
-    pub frustum: Matrix4<f32>,
+    /// Four clip planes per camera, one plane per row.
+    pub clip_planes1: Matrix4<f32>,
+    pub clip_planes2: Matrix4<f32>,
     pub draw_calls: u32,
 }
 

--- a/hotham/src/resources/render_context.rs
+++ b/hotham/src/resources/render_context.rs
@@ -253,7 +253,7 @@ impl RenderContext {
         // https://www.gamedevs.org/uploads/fast-extraction-viewing-frustum-planes-from-world-view-projection-matrix.pdf
         let normalize_plane = |p: RowVector4<_>| p / p.columns(0, 3).norm();
         let cull_data = CullData {
-            clip_planes1: Matrix4::<_>::from_rows(&[
+            left_clip_planes: Matrix4::<_>::from_rows(&[
                 normalize_plane(left_frustum_from_world.row(3) + left_frustum_from_world.row(0)),
                 normalize_plane(left_frustum_from_world.row(3) - left_frustum_from_world.row(0)),
                 // normalize_plane(left_frustum_from_world.row(3) + left_frustum_from_world.row(1)),
@@ -261,7 +261,7 @@ impl RenderContext {
                 normalize_plane(left_frustum_from_world.row(3) + left_frustum_from_world.row(2)),
                 normalize_plane(left_frustum_from_world.row(3) - left_frustum_from_world.row(2)),
             ]),
-            clip_planes2: Matrix4::<_>::from_rows(&[
+            right_clip_planes: Matrix4::<_>::from_rows(&[
                 normalize_plane(right_frustum_from_world.row(3) + right_frustum_from_world.row(0)),
                 normalize_plane(right_frustum_from_world.row(3) - right_frustum_from_world.row(0)),
                 // normalize_plane(right_frustum_from_world.row(3) + right_frustum_from_world.row(1)),
@@ -750,8 +750,8 @@ fn create_pipeline_layout(
 #[derive(Debug, Clone)]
 pub struct CullData {
     /// Four clip planes per camera, one plane per row.
-    pub clip_planes1: Matrix4<f32>,
-    pub clip_planes2: Matrix4<f32>,
+    pub left_clip_planes: Matrix4<f32>,
+    pub right_clip_planes: Matrix4<f32>,
     pub draw_calls: u32,
 }
 

--- a/hotham/src/shaders/culling.comp
+++ b/hotham/src/shaders/culling.comp
@@ -46,5 +46,5 @@ void main() {
         all(greaterThan(cullData.leftClipPlanes * center4, negRadius4)),
         all(greaterThan(cullData.rightClipPlanes * center4, negRadius4))
     ));
-    drawCommandsBuffer.drawCommands[id].instanceCount = isVisible ? 1 : 0;
+    drawCommandsBuffer.drawCommands[id].instanceCount = uint(isVisible);
 }

--- a/hotham/src/shaders/culling.comp
+++ b/hotham/src/shaders/culling.comp
@@ -27,8 +27,8 @@ layout(std430, set = 0, binding = 1) writeonly buffer DrawCommandsBuffer {
 } drawCommandsBuffer;
 
 layout(set = 0, binding = 2) uniform CullData {
-    mat4 clipPlanes1;
-    mat4 clipPlanes2;
+    mat4 leftClipPlanes;
+    mat4 rightClipPlanes;
     uint drawCalls;
 } cullData;
 
@@ -43,8 +43,8 @@ void main() {
 
     // Treat as visible if at least one eye may see it
     bool isVisible = any(bvec2(
-        all(greaterThan(cullData.clipPlanes1 * center4, negRadius4)),
-        all(greaterThan(cullData.clipPlanes2 * center4, negRadius4))
+        all(greaterThan(cullData.leftClipPlanes * center4, negRadius4)),
+        all(greaterThan(cullData.rightClipPlanes * center4, negRadius4))
     ));
     drawCommandsBuffer.drawCommands[id].instanceCount = isVisible ? 1 : 0;
 }

--- a/hotham/src/shaders/culling.comp
+++ b/hotham/src/shaders/culling.comp
@@ -27,37 +27,10 @@ layout(std430, set = 0, binding = 1) writeonly buffer DrawCommandsBuffer {
 } drawCommandsBuffer;
 
 layout(set = 0, binding = 2) uniform CullData {
-    mat4 frustum;
+    mat4 clipPlanes1;
+    mat4 clipPlanes2;
     uint drawCalls;
 } cullData;
-
-bool check_is_visible(mat4 mat, vec3 origin, float radius)
-{
-    uint plane_index = 0;
-    for (uint i = 0; i < 3; ++i)
-    {
-        for (uint j = 0; j < 2; ++j, ++plane_index)
-        {
-            if (plane_index == 2 || plane_index == 3)
-            {
-                continue;
-            }
-            const float sign  = (j > 0) ? 1.f : -1.f;
-            vec4        plane = vec4(0, 0, 0, 0);
-            for (uint k = 0; k < 4; ++k)
-            {
-                plane[k] = mat[k][3] + sign * mat[k][i];
-            }
-            plane.xyzw /= sqrt(dot(plane.xyz, plane.xyz));
-            if (dot(origin, plane.xyz) + plane.w + radius < 0)
-            {
-                return false;
-            }
-        }
-    }
-
-    return true;
-}
 
 void main() {
     uint id = gl_GlobalInvocationID.x;
@@ -65,10 +38,13 @@ void main() {
     if (id >= cullData.drawCalls) { return; }
 
     DrawData d = drawDataBuffer.data[id];
-    vec3 center = d.boundingSphere.xyz;
-    float radius = d.boundingSphere.w;
+    vec4 center4 = vec4(d.boundingSphere.xyz, 1);
+    vec4 negRadius4 = -d.boundingSphere.wwww;
 
-    // // Check each eye to see if the object is visible
-    bool isVisible = check_is_visible(cullData.frustum, center, radius);
+    // Treat as visible if at least one eye may see it
+    bool isVisible = any(bvec2(
+        all(greaterThan(cullData.clipPlanes1 * center4, negRadius4)),
+        all(greaterThan(cullData.clipPlanes2 * center4, negRadius4))
+    ));
     drawCommandsBuffer.drawCommands[id].instanceCount = isVisible ? 1 : 0;
 }

--- a/hotham/src/shaders/culling.comp
+++ b/hotham/src/shaders/culling.comp
@@ -3,11 +3,11 @@
 layout (local_size_x = 256) in;
 struct VkDrawIndexedIndirectCommand
 {
-	uint indexCount;
-	uint instanceCount;
-	uint firstIndex;
-	int  vertexOffset;
-	uint firstInstance;
+    uint indexCount;
+    uint instanceCount;
+    uint firstIndex;
+    int  vertexOffset;
+    uint firstInstance;
 };
 
 struct DrawData {
@@ -28,47 +28,47 @@ layout(std430, set = 0, binding = 1) writeonly buffer DrawCommandsBuffer {
 
 layout(set = 0, binding = 2) uniform CullData {
     mat4 frustum;
-	uint drawCalls;
+    uint drawCalls;
 } cullData;
 
 bool check_is_visible(mat4 mat, vec3 origin, float radius)
 {
-	uint plane_index = 0;
-	for (uint i = 0; i < 3; ++i)
-	{
-		for (uint j = 0; j < 2; ++j, ++plane_index)
-		{
-			if (plane_index == 2 || plane_index == 3)
-			{
-				continue;
-			}
-			const float sign  = (j > 0) ? 1.f : -1.f;
-			vec4        plane = vec4(0, 0, 0, 0);
-			for (uint k = 0; k < 4; ++k)
-			{
-				plane[k] = mat[k][3] + sign * mat[k][i];
-			}
-			plane.xyzw /= sqrt(dot(plane.xyz, plane.xyz));
-			if (dot(origin, plane.xyz) + plane.w + radius < 0)
-			{
-				return false;
-			}
-		}
-	}
+    uint plane_index = 0;
+    for (uint i = 0; i < 3; ++i)
+    {
+        for (uint j = 0; j < 2; ++j, ++plane_index)
+        {
+            if (plane_index == 2 || plane_index == 3)
+            {
+                continue;
+            }
+            const float sign  = (j > 0) ? 1.f : -1.f;
+            vec4        plane = vec4(0, 0, 0, 0);
+            for (uint k = 0; k < 4; ++k)
+            {
+                plane[k] = mat[k][3] + sign * mat[k][i];
+            }
+            plane.xyzw /= sqrt(dot(plane.xyz, plane.xyz));
+            if (dot(origin, plane.xyz) + plane.w + radius < 0)
+            {
+                return false;
+            }
+        }
+    }
 
-	return true;
+    return true;
 }
 
 void main() {
     uint id = gl_GlobalInvocationID.x;
 
-	if (id >= cullData.drawCalls) { return; }
+    if (id >= cullData.drawCalls) { return; }
 
     DrawData d = drawDataBuffer.data[id];
     vec3 center = d.boundingSphere.xyz;
     float radius = d.boundingSphere.w;
 
-	// // Check each eye to see if the object is visible
+    // // Check each eye to see if the object is visible
     bool isVisible = check_is_visible(cullData.frustum, center, radius);
     drawCommandsBuffer.drawCommands[id].instanceCount = isVisible ? 1 : 0;
 }


### PR DESCRIPTION
* Handle all pending input events in `update_camera`- This fixes laggy input in the simulator when using a mouse with high refresh rate.
* Let the second camera follow the first. - This makes the interpolated pose culling work for the simulator.
* Replace shared camera frustum with separate frustums for the two cameras. - This removes the interpolated pose altogether.
* Move some redundant computations in `culling.comp` to the CPU so that the GPU code can be simplified.