### PR TITLE
Fix build by fixing ndk-glue version

### DIFF
--- a/hotham/Cargo.toml
+++ b/hotham/Cargo.toml
@@ -46,4 +46,4 @@ serde_json = "1.0"
 [target.'cfg(target_os = "android")'.dependencies]
 jni = "0.19.0"
 ndk = "0.6"
-ndk-glue = ">=0.6.2"
+ndk-glue = "0.6"


### PR DESCRIPTION
There is a newly released ndk version 0.7.0 that sneaks in and causes build issues. This is an attempt to resolve the build problems until we choose to upgrade.