### PR TITLE
Bump dependencies

### DIFF
--- a/hotham-simulator/Cargo.toml
+++ b/hotham-simulator/Cargo.toml
@@ -16,7 +16,7 @@ openxr-sys = "0.9"
 rand = "0.8"
 vk-shader-macros = "0.2.8"
 winit = "0.26"
-nalgebra = "0.29.0"
+nalgebra = "0.31.0"
 
 [build-dependencies]
 bindgen = "*"

--- a/hotham/Cargo.toml
+++ b/hotham/Cargo.toml
@@ -21,7 +21,7 @@ gltf = {version = "1.0", features = ["KHR_materials_pbrSpecularGlossiness", "nam
 hecs = "0.7.7"
 hotham-debug-server = {path = "../hotham-debug-server", version = "0.2"}
 id-arena = "2.2.1"
-image = {version = "0.23", default-features = false, features = ["jpeg", "png"]}
+image = {version = "0.24.3", default-features = false, features = ["jpeg", "png"]}
 itertools = "0.10.0"
 ktx2 = "0.3"
 memoffset = "0.6.5"


### PR DESCRIPTION
This follows #282. 

Bump dependencies to reduce depending on multiple versions of crates and move forwards in general.

The following lines disappear from the output of `cargo tree -d`:
```
nalgebra v0.29.0
└── hotham-simulator v0.2.0 (C:\Users\morot\source\repos\hotham\hotham-simulator)

nalgebra v0.31.0
├── hotham v0.2.0 (C:\Users\morot\source\repos\hotham\hotham) (*)
├── parry3d v0.9.0
│   └── rapier3d v0.14.0 (*)
└── rapier3d v0.14.0 (*)

num-rational v0.3.2
└── image v0.23.14 (*)

num-rational v0.4.1
├── nalgebra v0.29.0 (*)
└── nalgebra v0.31.0 (*)

simba v0.6.0
└── nalgebra v0.29.0 (*)

simba v0.7.1
├── nalgebra v0.31.0 (*)
├── parry3d v0.9.0 (*)
└── rapier3d v0.14.0 (*)
```

This leaves us with duplicated versions of `cfg-if` and `raw-window-handle` (not introduced here).