### PR TITLE
Reduce size of PrimitiveCullData

### DIFF
--- a/hotham/src/rendering/resources.rs
+++ b/hotham/src/rendering/resources.rs
@@ -139,8 +139,8 @@ pub struct DrawData {
 #[derive(Debug, Default, Clone)]
 #[repr(C, align(16))]
 pub(crate) struct PrimitiveCullData {
-    pub draw_data: DrawData,
     pub bounding_sphere: Vector4<f32>,
+    pub index_instance: u32,
     pub index_offset: u32,
     pub visible: bool,
 }

--- a/hotham/src/shaders/culling.comp
+++ b/hotham/src/shaders/culling.comp
@@ -10,17 +10,9 @@ struct VkDrawIndexedIndirectCommand
     uint firstInstance;
 };
 
-
-struct DrawData {
-    mat4 transform;
-    mat4 inverseTranspose;
-    uint materialID;
-    uint skinID;
-};
-
 struct PrimitiveCullData {
-    DrawData drawData;
     vec4 boundingSphere;
+    uint indexInstance;
     uint indexOffset;
     bool visible;
 };


### PR DESCRIPTION
Remove `draw_data` from `PrimitiveCullData` and replace it with an index that is used for creating draw data only for instances that pass the cull test. This makes the cull buffer smaller with the hopes of improving performance. Please help me benchmark it to see if it makes any practical difference.