### PR TITLE
Fix bounding sphere transformations

### DIFF
--- a/hotham/src/rendering/primitive.rs
+++ b/hotham/src/rendering/primitive.rs
@@ -143,7 +143,13 @@ impl Primitive {
         let center_in_local: Point3<_> = self.bounding_sphere.xyz().into();
         let center_in_world =
             Point3::<_>::from_homogeneous(transform.0 * center_in_local.to_homogeneous()).unwrap();
+
+        // The linear part contains the rotation and scale, we are interested in the scale.
         let world_from_local_linear_part = transform.0.fixed_slice::<3, 3>(0, 0);
+
+        // The scale of the sphere is taken as the largest scale in any dimension.
+        // If the scale is non-uniform, there could be a tighter bounding sphere.
+        // If the scale is uniform, the quality of the bounding sphere will be unchanged.
         let scale = world_from_local_linear_part
             .column(0)
             .magnitude_squared()

--- a/hotham/src/rendering/primitive.rs
+++ b/hotham/src/rendering/primitive.rs
@@ -1,11 +1,11 @@
 use crate::{
     asset_importer::ImportContext,
-    components::Transform,
+    components::TransformMatrix,
     rendering::{material::NO_MATERIAL, vertex::Vertex},
     resources::render_context,
 };
 use itertools::izip;
-use nalgebra::{vector, Vector3, Vector4};
+use nalgebra::{vector, Point3, Vector3, Vector4};
 use render_context::RenderContext;
 
 /// Geometry for a mesh
@@ -139,14 +139,26 @@ impl Primitive {
     }
 
     /// Get a bounding sphere for the primitive, applying a transform
-    pub fn get_bounding_sphere(&self, transform: &Transform) -> Vector4<f32> {
-        let mut center = self.bounding_sphere.xyz();
-        let mut radius = self.bounding_sphere.w;
+    pub fn get_bounding_sphere(&self, transform: &TransformMatrix) -> Vector4<f32> {
+        let center_in_local: Point3<_> = self.bounding_sphere.xyz().into();
+        let center_in_world =
+            Point3::<_>::from_homogeneous(transform.0 * center_in_local.to_homogeneous()).unwrap();
+        let world_from_local_linear_part = transform.0.fixed_slice::<3, 3>(0, 0);
+        let scale = world_from_local_linear_part
+            .column(0)
+            .magnitude_squared()
+            .max(world_from_local_linear_part.column(1).magnitude_squared())
+            .max(world_from_local_linear_part.column(2).magnitude_squared())
+            .sqrt();
+        let radius_in_world = self.bounding_sphere.w * scale;
 
-        center += transform.translation;
-        radius *= transform.scale.max();
-
-        [center.x, center.y, center.z, radius].into()
+        [
+            center_in_world.x,
+            center_in_world.y,
+            center_in_world.z,
+            radius_in_world,
+        ]
+        .into()
     }
 }
 

--- a/hotham/src/rendering/primitive.rs
+++ b/hotham/src/rendering/primitive.rs
@@ -148,8 +148,12 @@ impl Primitive {
         let world_from_local_linear_part = transform.0.fixed_slice::<3, 3>(0, 0);
 
         // The scale of the sphere is taken as the largest scale in any dimension.
-        // If the scale is non-uniform, there could be a tighter bounding sphere.
         // If the scale is uniform, the quality of the bounding sphere will be unchanged.
+        // If the scale is non-uniform and axis aligned in local space, there could be a tighter bounding sphere.
+        // If the scale is non-uniform and not axis aligned in local space (skew), the bounding sphere may be too tight.
+        // If the case with skew becomes a problem in practice, there are several ways to solve it, eg:
+        // * Using singular value decomposition can give a solution similar to the axis aligned case.
+        // * Using a fudge factor can ensure correctness with a bounding sphere that usually is bigger than it needs to be.
         let scale = world_from_local_linear_part
             .column(0)
             .magnitude_squared()

--- a/hotham/src/systems/mod.rs
+++ b/hotham/src/systems/mod.rs
@@ -44,17 +44,8 @@ pub struct Queries<'a> {
     pub skins_query: PreparedQuery<(&'a Skin, &'a TransformMatrix)>,
     pub parent_query: PreparedQuery<&'a Parent>,
     #[allow(clippy::type_complexity)]
-    pub rendering_query: PreparedQuery<
-        With<
-            Visible,
-            (
-                &'a Mesh,
-                &'a Transform,
-                &'a TransformMatrix,
-                Option<&'a Skin>,
-            ),
-        >,
-    >,
+    pub rendering_query:
+        PreparedQuery<With<Visible, (&'a Mesh, &'a TransformMatrix, Option<&'a Skin>)>>,
     pub roots_query: PreparedQuery<Without<Parent, &'a TransformMatrix>>,
     pub update_rigid_body_transforms_query: PreparedQuery<(&'a RigidBody, &'a mut Transform)>,
     pub update_transform_matrix_query: PreparedQuery<(&'a Transform, &'a mut TransformMatrix)>,

--- a/hotham/src/systems/rendering.rs
+++ b/hotham/src/systems/rendering.rs
@@ -62,7 +62,7 @@ pub fn rendering_system(
                 .instances
                 .push(Instance {
                     transform_matrix: transform_matrix.0,
-                    bounding_sphere: primitive.get_bounding_sphere(transform),
+                    bounding_sphere: primitive.get_bounding_sphere(transform_matrix),
                     skin_id,
                 });
         }

--- a/hotham/src/systems/rendering.rs
+++ b/hotham/src/systems/rendering.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, convert::TryInto};
 
 use crate::{
-    components::{skin::NO_SKIN, Mesh, Skin, Transform, TransformMatrix, Visible},
+    components::{skin::NO_SKIN, Mesh, Skin, TransformMatrix, Visible},
     rendering::{
         primitive::Primitive,
         resources::{DrawData, PrimitiveCullData},
@@ -32,7 +32,7 @@ struct InstancedPrimitive {
 /// - AFTER: ensure you have called render_context.end_frame
 #[allow(clippy::type_complexity)]
 pub fn rendering_system(
-    query: &mut PreparedQuery<With<Visible, (&Mesh, &Transform, &TransformMatrix, Option<&Skin>)>>,
+    query: &mut PreparedQuery<With<Visible, (&Mesh, &TransformMatrix, Option<&Skin>)>>,
     world: &mut World,
     vulkan_context: &VulkanContext,
     render_context: &mut RenderContext,
@@ -47,7 +47,7 @@ pub fn rendering_system(
     let mut primitive_map: HashMap<u32, InstancedPrimitive> = Default::default();
     let meshes = &render_context.resources.mesh_data;
 
-    for (_, (mesh, transform, transform_matrix, skin)) in query.query_mut(world) {
+    for (_, (mesh, transform_matrix, skin)) in query.query_mut(world) {
         let mesh = meshes.get(mesh.handle).unwrap();
         let skin_id = skin.map(|s| s.id).unwrap_or(NO_SKIN);
         for primitive in &mesh.primitives {


### PR DESCRIPTION
~~This follows #291.~~

Use `GlobalTransform` instead of `LocalTransform` for computing transformed bounding spheres. This takes the full transformation from local to world into account and properly deals with hierarchies of parents and children.