### PR TITLE
Refactor transformations - rename variables

### DIFF
--- a/benchmarks/stress-test/src/lib.rs
+++ b/benchmarks/stress-test/src/lib.rs
@@ -258,8 +258,8 @@ fn model_system(
 }
 
 fn rotate_models(world: &mut World, total_time: f32) {
-    for (_, transform) in world.query_mut::<With<Mesh, &mut LocalTransform>>() {
-        transform.rotation =
+    for (_, local_transform) in world.query_mut::<With<Mesh, &mut LocalTransform>>() {
+        local_transform.rotation =
             UnitQuaternion::from_euler_angles(90.0_f32.to_radians(), total_time.sin() * 2., 0.);
     }
 }
@@ -275,17 +275,17 @@ fn rearrange_models(world: &mut World) {
     let mut row = 0;
     let mut column = 0;
 
-    for (_, transform) in query_iter {
+    for (_, local_transform) in query_iter {
         if column >= column_size {
             column = 0;
             row += 1;
         }
 
-        transform.translation.x = (column as f32) - half_column_size;
-        transform.translation.y = (row as f32) - 0.5;
-        transform.translation.z = -4.0;
+        local_transform.translation.x = (column as f32) - half_column_size;
+        local_transform.translation.y = (row as f32) - 0.5;
+        local_transform.translation.z = -4.0;
 
-        transform.scale = Vector3::repeat(scale);
+        local_transform.scale = Vector3::repeat(scale);
 
         column += 1;
     }
@@ -308,12 +308,17 @@ fn create_mesh(render_context: &mut RenderContext, world: &mut World) {
         render_context,
     );
     update_mesh(1, &mesh, render_context);
-    let transform = LocalTransform {
+    let local_transform = LocalTransform {
         translation: [0., 1., -1.].into(),
         ..Default::default()
     };
 
-    world.spawn((Visible {}, mesh, transform, GlobalTransform::default()));
+    world.spawn((
+        Visible {},
+        mesh,
+        local_transform,
+        GlobalTransform::default(),
+    ));
 }
 
 fn update_mesh(step: usize, mesh: &Mesh, render_context: &mut RenderContext) {

--- a/examples/crab-saber/src/systems/sabers.rs
+++ b/examples/crab-saber/src/systems/sabers.rs
@@ -136,8 +136,11 @@ mod tests {
             &physics_context,
         );
 
-        let transform = world.get::<LocalTransform>(saber).unwrap();
-        approx::assert_relative_eq!(transform.translation, [-0.2, 1.328827, -0.433918].into());
+        let local_transform = world.get::<LocalTransform>(saber).unwrap();
+        approx::assert_relative_eq!(
+            local_transform.translation,
+            [-0.2, 1.328827, -0.433918].into()
+        );
     }
 
     #[test]

--- a/examples/simple-scene/src/lib.rs
+++ b/examples/simple-scene/src/lib.rs
@@ -73,12 +73,12 @@ fn add_helmet(
 ) {
     let helmet = add_model_to_world("Damaged Helmet", models, world, None)
         .expect("Could not find Damaged Helmet");
-    let mut transform = world.get_mut::<LocalTransform>(helmet).unwrap();
-    transform.translation.z = -1.;
-    transform.translation.y = 1.4;
-    transform.scale = [0.5, 0.5, 0.5].into();
-    let position = transform.position();
-    drop(transform);
+    let mut local_transform = world.get_mut::<LocalTransform>(helmet).unwrap();
+    local_transform.translation.z = -1.;
+    local_transform.translation.y = 1.4;
+    local_transform.scale = [0.5, 0.5, 0.5].into();
+    let position = local_transform.position();
+    drop(local_transform);
     let collider = ColliderBuilder::ball(0.35)
         .active_collision_types(ActiveCollisionTypes::all())
         .active_events(ActiveEvents::COLLISION_EVENTS)

--- a/hotham/src/asset_importer/mod.rs
+++ b/hotham/src/asset_importer/mod.rs
@@ -162,7 +162,7 @@ fn load_node(
     world: &mut World,
     is_root: bool,
 ) -> Entity {
-    let transform = LocalTransform::load(node_data.transform());
+    let local_transform = LocalTransform::load(node_data.transform());
     let global_transform = GlobalTransform(node_data.transform().matrix().into());
     let info = Info {
         name: node_data
@@ -171,7 +171,7 @@ fn load_node(
             .unwrap_or(format!("Node {}", node_data.index())),
         node_id: node_data.index(),
     };
-    let this_entity = world.spawn((transform, global_transform, info));
+    let this_entity = world.spawn((local_transform, global_transform, info));
     import_context
         .node_entity_map
         .insert(node_data.index(), this_entity);
@@ -233,9 +233,9 @@ pub fn add_model_to_world(
 
     // Go through each entity in the source world and clone its components into the new world.
     for (source_entity, destination_entity) in &entity_map {
-        if let Ok(transform) = source_world.get_mut::<LocalTransform>(*source_entity) {
+        if let Ok(local_transform) = source_world.get_mut::<LocalTransform>(*source_entity) {
             destination_world
-                .insert_one(*destination_entity, *transform)
+                .insert_one(*destination_entity, *local_transform)
                 .unwrap();
         }
 
@@ -388,7 +388,7 @@ mod tests {
             assert!(model.is_some(), "Model {} could not be added", name);
 
             let model = model.unwrap();
-            let (info, transform, mesh, ..) = world
+            let (info, local_transform, mesh, ..) = world
                 .query_one_mut::<(&Info, &LocalTransform, &Mesh, &GlobalTransform, &Root)>(model)
                 .unwrap();
             let mesh = render_context.resources.mesh_data.get(mesh.handle).unwrap();
@@ -419,12 +419,12 @@ mod tests {
 
             // Ensure the transform was populated correctly
             assert_eq!(
-                transform.translation, *translation,
+                local_transform.translation, *translation,
                 "Model {} has wrong translation",
                 name
             );
             assert_eq!(
-                transform.rotation,
+                local_transform.rotation,
                 UnitQuaternion::new_normalize(*rotation),
                 "Model {} has wrong rotation",
                 name

--- a/hotham/src/components/parent.rs
+++ b/hotham/src/components/parent.rs
@@ -1,6 +1,6 @@
 use hecs::Entity;
 
 /// Component added to indicate that an entity has a parent
-/// Used by `update_parent_transform_matrix_system`
+/// Used by `update_global_transform_with_parent_system`
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Parent(pub Entity);

--- a/hotham/src/rendering/primitive.rs
+++ b/hotham/src/rendering/primitive.rs
@@ -139,13 +139,14 @@ impl Primitive {
     }
 
     /// Get a bounding sphere for the primitive, applying a transform
-    pub fn get_bounding_sphere(&self, transform: &GlobalTransform) -> Vector4<f32> {
+    pub fn get_bounding_sphere(&self, global_transform: &GlobalTransform) -> Vector4<f32> {
         let center_in_local: Point3<_> = self.bounding_sphere.xyz().into();
         let center_in_global =
-            Point3::<_>::from_homogeneous(transform.0 * center_in_local.to_homogeneous()).unwrap();
+            Point3::<_>::from_homogeneous(global_transform.0 * center_in_local.to_homogeneous())
+                .unwrap();
 
         // The linear part contains the rotation and scale, we are interested in the scale.
-        let global_from_local_linear_part = transform.0.fixed_slice::<3, 3>(0, 0);
+        let global_from_local_linear_part = global_transform.0.fixed_slice::<3, 3>(0, 0);
 
         // The scale of the sphere is taken as the largest scale in any dimension.
         // If the scale is uniform, the quality of the bounding sphere will be unchanged.

--- a/hotham/src/rendering/resources.rs
+++ b/hotham/src/rendering/resources.rs
@@ -126,7 +126,7 @@ impl Resources {
 #[repr(C, align(16))]
 pub struct DrawData {
     /// The transform of the parent mesh
-    pub transform: Matrix4<f32>,
+    pub global_from_local: Matrix4<f32>,
     /// The inverse transpose of the transform of the parent mesh
     pub inverse_transpose: Matrix4<f32>,
     /// The ID of the material to use.

--- a/hotham/src/shaders/common.glsl
+++ b/hotham/src/shaders/common.glsl
@@ -7,7 +7,7 @@
 #define MAX_JOINTS 64
 
 struct DrawData {
-    mat4 transform;
+    mat4 globalFromLocal;
     mat4 inverseTranspose;
     uint materialID;
     uint skinID;
@@ -44,7 +44,7 @@ layout(std430, set = 0, binding = 2) readonly buffer SkinsBuffer {
     mat4 jointMatrices[100][64]; // dynamically sized array of 64 element long arrays of mat4.
 } skinsBuffer;
 
-layout (set = 0, binding = 3) readonly uniform SceneData { 
+layout (set = 0, binding = 3) readonly uniform SceneData {
     mat4 viewProjection[2];
     vec4 cameraPosition[2];
     vec4 lightDirection;

--- a/hotham/src/shaders/pbr.frag
+++ b/hotham/src/shaders/pbr.frag
@@ -9,7 +9,7 @@ const float epsilon = 1e-6;
 #define DEFAULT_IBL_SCALE 0.4
 
 // Inputs
-layout (location = 0) in vec3 inWorldPos;
+layout (location = 0) in vec3 inGlobalPos;
 layout (location = 1) in vec3 inNormal;
 layout (location = 2) in vec2 inUV;
 layout (location = 3) flat in uint inMaterialID;
@@ -71,8 +71,8 @@ vec3 getNormal(uint normalTextureID)
 	tangentNormal.xy = texture(textures[normalTextureID], inUV).ga * 2.0 - 1.0;
 	tangentNormal.z = sqrt(1 - dot(tangentNormal.xy, tangentNormal.xy));
 
-	vec3 q1 = dFdx(inWorldPos);
-	vec3 q2 = dFdy(inWorldPos);
+	vec3 q1 = dFdx(inGlobalPos);
+	vec3 q2 = dFdy(inGlobalPos);
 	vec2 st1 = dFdx(inUV);
 	vec2 st2 = dFdy(inUV);
 
@@ -251,7 +251,7 @@ void main()
 	vec3 specularEnvironmentR90 = vec3(1.0, 1.0, 1.0) * reflectance90;
 
 	vec3 n = (material.normalTextureID == NO_TEXTURE) ? normalize(inNormal) : getNormal(material.normalTextureID);
-	vec3 v = normalize(sceneData.cameraPosition[gl_ViewIndex].xyz - inWorldPos);    // Vector from surface point to camera
+	vec3 v = normalize(sceneData.cameraPosition[gl_ViewIndex].xyz - inGlobalPos);    // Vector from surface point to camera
 	vec3 l = normalize(sceneData.lightDirection.xyz);     // Vector from surface point to light
 	vec3 h = normalize(l+v);                        // Half vector between both l and v
 	vec3 reflection = -normalize(reflect(v, n));

--- a/hotham/src/shaders/pbr.vert
+++ b/hotham/src/shaders/pbr.vert
@@ -11,7 +11,7 @@ layout (location = 2) in vec2 inUV;
 layout (location = 3) in vec4 inJoint;
 layout (location = 4) in vec4 inWeight;
 
-layout (location = 0) out vec4 outWorldPos;
+layout (location = 0) out vec4 outGlobalPos;
 layout (location = 1) out vec3 outNormal;
 layout (location = 2) out vec2 outUV;
 layout (location = 3) flat out uint outMaterialID;
@@ -27,7 +27,7 @@ void main()
 
 	if (d.skinID == NO_SKIN) {
 		// Mesh has no skin
-		outWorldPos = d.transform * vec4(inPos, 1.0);
+		outGlobalPos = d.globalFromLocal * vec4(inPos, 1.0);
 		if (length(inNormal) == 0.0) {
 			outNormal = inNormal;
 		} else {
@@ -42,11 +42,11 @@ void main()
 			inWeight.z * jointMatrices[int(inJoint.z)] +
 			inWeight.w * jointMatrices[int(inJoint.w)];
 
-		outWorldPos = d.transform * skinMatrix * vec4(inPos, 1.0);
+		outGlobalPos = d.globalFromLocal * skinMatrix * vec4(inPos, 1.0);
 		outNormal = normalize(mat3(d.inverseTranspose) * mat3(skinMatrix) * inNormal);
 	}
 
 	outUV = inUV;
 	outMaterialID = d.materialID;
-	gl_Position = sceneData.viewProjection[gl_ViewIndex] * outWorldPos;
+	gl_Position = sceneData.viewProjection[gl_ViewIndex] * outGlobalPos;
 }

--- a/hotham/src/systems/animation.rs
+++ b/hotham/src/systems/animation.rs
@@ -10,12 +10,12 @@ pub fn animation_system(query: &mut PreparedQuery<&AnimationController>, world: 
         let blend_amount = controller.blend_amount;
 
         for target in &controller.targets {
-            let mut transform = world.get_mut::<LocalTransform>(target.target).unwrap();
-            transform.translation =
+            let mut local_transform = world.get_mut::<LocalTransform>(target.target).unwrap();
+            local_transform.translation =
                 target.translations[blend_from].lerp(&target.translations[blend_to], blend_amount);
-            transform.rotation =
+            local_transform.rotation =
                 target.rotations[blend_from].slerp(&target.rotations[blend_to], blend_amount);
-            transform.scale =
+            local_transform.scale =
                 target.scales[blend_from].lerp(&target.scales[blend_to], blend_amount);
         }
     }

--- a/hotham/src/systems/hands.rs
+++ b/hotham/src/systems/hands.rs
@@ -130,12 +130,12 @@ mod tests {
 
         schedule(&mut world, &mut xr_context, &mut physics_context);
 
-        let (transform, hand, animation_controller) = world
+        let (local_transform, hand, animation_controller) = world
             .query_one_mut::<(&LocalTransform, &Hand, &AnimationController)>(hand)
             .unwrap();
 
         assert_relative_eq!(hand.grip_value, 0.0);
-        assert_relative_eq!(transform.translation, vector![-0.2, 1.4, -0.5]);
+        assert_relative_eq!(local_transform.translation, vector![-0.2, 1.4, -0.5]);
         assert_relative_eq!(animation_controller.blend_amount, 0.0);
     }
 
@@ -153,8 +153,8 @@ mod tests {
 
         schedule(&mut world, &mut xr_context, &mut physics_context);
 
-        let transform = world.get_mut::<LocalTransform>(grabbed_entity).unwrap();
-        assert_relative_eq!(transform.translation, vector![-0.2, 1.4, -0.5]);
+        let local_transform = world.get_mut::<LocalTransform>(grabbed_entity).unwrap();
+        assert_relative_eq!(local_transform.translation, vector![-0.2, 1.4, -0.5]);
     }
 
     // HELPER FUNCTIONS

--- a/hotham/src/systems/skinning.rs
+++ b/hotham/src/systems/skinning.rs
@@ -13,10 +13,10 @@ pub fn skinning_system(
     world: &mut World,
     render_context: &mut RenderContext,
 ) {
-    for (_, (skin, transform_matrix)) in skins_query.query(world).iter() {
+    for (_, (skin, global_transform)) in skins_query.query(world).iter() {
         let buffer = unsafe { render_context.resources.skins_buffer.as_slice_mut() };
         let joint_matrices = &mut buffer[skin.id as usize];
-        let inverse_transform = transform_matrix.0.try_inverse().unwrap();
+        let inverse_transform = global_transform.0.try_inverse().unwrap();
 
         for (n, (joint, inverse_bind_matrix)) in skin
             .joints
@@ -57,8 +57,8 @@ mod tests {
         // Muck all the joints up
         for (_, skin) in world.query::<&Skin>().iter() {
             for joint in &skin.joints {
-                let mut transform_matrix = world.get_mut::<GlobalTransform>(*joint).unwrap();
-                transform_matrix.0 = Matrix4::zeros();
+                let mut global_transform = world.get_mut::<GlobalTransform>(*joint).unwrap();
+                global_transform.0 = Matrix4::zeros();
             }
         }
         skinning_system(&mut Default::default(), &mut world, &mut render_context);

--- a/hotham/src/systems/skinning.rs
+++ b/hotham/src/systems/skinning.rs
@@ -16,17 +16,17 @@ pub fn skinning_system(
     for (_, (skin, global_transform)) in skins_query.query(world).iter() {
         let buffer = unsafe { render_context.resources.skins_buffer.as_slice_mut() };
         let joint_matrices = &mut buffer[skin.id as usize];
-        let inverse_transform = global_transform.0.try_inverse().unwrap();
+        let local_from_global = global_transform.0.try_inverse().unwrap();
 
-        for (n, (joint, inverse_bind_matrix)) in skin
+        for (n, (joint, joint_from_mesh)) in skin
             .joints
             .iter()
             .zip(skin.inverse_bind_matrices.iter())
             .enumerate()
         {
-            let joint_transform = world.get::<GlobalTransform>(*joint).unwrap().0;
-            let joint_matrix = inverse_transform * joint_transform * inverse_bind_matrix;
-            joint_matrices[n] = joint_matrix;
+            let global_from_joint = world.get::<GlobalTransform>(*joint).unwrap().0;
+            let local_from_mesh = local_from_global * global_from_joint * joint_from_mesh;
+            joint_matrices[n] = local_from_mesh;
         }
     }
 }

--- a/hotham/src/systems/update_global_transform.rs
+++ b/hotham/src/systems/update_global_transform.rs
@@ -3,7 +3,7 @@ use nalgebra::Matrix4;
 use crate::components::{GlobalTransform, LocalTransform};
 use hecs::{PreparedQuery, World};
 
-/// Update transform matrix system
+/// Update global transform matrix system
 /// Walks through each LocalTransform and applies it to a 4x4 matrix used by the vertex shader
 pub fn update_global_transform_system(
     query: &mut PreparedQuery<(&LocalTransform, &mut GlobalTransform)>,

--- a/hotham/src/systems/update_global_transform.rs
+++ b/hotham/src/systems/update_global_transform.rs
@@ -9,10 +9,10 @@ pub fn update_global_transform_system(
     query: &mut PreparedQuery<(&LocalTransform, &mut GlobalTransform)>,
     world: &mut World,
 ) {
-    for (_, (transform, transform_matrix)) in query.query_mut(world) {
-        transform_matrix.0 = Matrix4::new_translation(&transform.translation)
-            * Matrix4::from(transform.rotation)
-            * Matrix4::new_nonuniform_scaling(&transform.scale);
+    for (_, (local_transform, global_transform)) in query.query_mut(world) {
+        global_transform.0 = Matrix4::new_translation(&local_transform.translation)
+            * Matrix4::from(local_transform.rotation)
+            * Matrix4::new_nonuniform_scaling(&local_transform.scale);
     }
 }
 
@@ -27,10 +27,10 @@ mod tests {
     #[test]
     pub fn test_update_global_transform_system() {
         let mut world = World::new();
-        let transform = LocalTransform::default();
-        let transform_matrix = GlobalTransform::default();
+        let local_transform = LocalTransform::default();
+        let global_transform = GlobalTransform::default();
 
-        let entity = world.spawn((transform, transform_matrix));
+        let entity = world.spawn((local_transform, global_transform));
 
         {
             let matrix = world.get_mut::<GlobalTransform>(entity).unwrap();
@@ -41,10 +41,10 @@ mod tests {
         let test_rotation = UnitQuaternion::from_euler_angles(0.3, 0.3, 0.3);
 
         {
-            let mut transform = world.get_mut::<LocalTransform>(entity).unwrap();
-            transform.translation = test_translation;
-            transform.rotation = test_rotation;
-            transform.scale = test_translation;
+            let mut local_transform = world.get_mut::<LocalTransform>(entity).unwrap();
+            local_transform.translation = test_translation;
+            local_transform.rotation = test_rotation;
+            local_transform.scale = test_translation;
         }
 
         update_global_transform_system(&mut Default::default(), &mut world);
@@ -53,7 +53,7 @@ mod tests {
             * Matrix4::from(test_rotation)
             * Matrix4::new_nonuniform_scaling(&vector![5.0, 1.0, 2.0]);
 
-        let matrix = world.get_mut::<GlobalTransform>(entity).unwrap();
-        assert_relative_eq!(matrix.0, expected_matrix);
+        let global_transform = world.get_mut::<GlobalTransform>(entity).unwrap();
+        assert_relative_eq!(global_transform.0, expected_matrix);
     }
 }

--- a/hotham/src/systems/update_global_transform_with_parent.rs
+++ b/hotham/src/systems/update_global_transform_with_parent.rs
@@ -102,12 +102,12 @@ mod tests {
                 name: format!("Node {}", n),
                 node_id: n,
             };
-            let transform = LocalTransform {
+            let local_transform = LocalTransform {
                 translation: vector![1.0, 1.0, 1.0],
                 ..Default::default()
             };
             let matrix = GlobalTransform::default();
-            let entity = world.spawn((info, transform, matrix));
+            let entity = world.spawn((info, local_transform, matrix));
             node_entity.insert(n, entity);
             entity_node.insert(entity, n);
         }
@@ -123,8 +123,8 @@ mod tests {
 
         let root_entity = node_entity.get(&0).unwrap();
         {
-            let mut transform = world.get_mut::<LocalTransform>(*root_entity).unwrap();
-            transform.translation = vector![100.0, 100.0, 100.0];
+            let mut local_transform = world.get_mut::<LocalTransform>(*root_entity).unwrap();
+            local_transform.translation = vector![100.0, 100.0, 100.0];
         }
         schedule(&mut world);
 

--- a/hotham/src/systems/update_local_transform_with_rigid_body.rs
+++ b/hotham/src/systems/update_local_transform_with_rigid_body.rs
@@ -12,17 +12,17 @@ pub fn update_local_transform_with_rigid_body_system(
     world: &mut World,
     physics_context: &PhysicsContext,
 ) {
-    for (_, (rigid_body, transform)) in query.query_mut(world) {
+    for (_, (rigid_body, local_transform)) in query.query_mut(world) {
         let rigid_body = &physics_context.rigid_bodies[rigid_body.handle];
         let position = rigid_body.position();
 
         // Update translation
-        transform.translation.x = position.translation.x;
-        transform.translation.y = position.translation.y;
-        transform.translation.z = position.translation.z;
+        local_transform.translation.x = position.translation.x;
+        local_transform.translation.y = position.translation.y;
+        local_transform.translation.z = position.translation.z;
 
         // Update rotation
-        transform.rotation = UnitQuaternion::new_normalize(*position.rotation.quaternion());
+        local_transform.rotation = UnitQuaternion::new_normalize(*position.rotation.quaternion());
     }
 }
 
@@ -59,9 +59,9 @@ mod tests {
         schedule(&mut physics_context, &mut query, &mut world);
         schedule(&mut physics_context, &mut query, &mut world);
 
-        let transform = world.get::<LocalTransform>(entity).unwrap();
-        assert_relative_eq!(transform.translation, vector![1.0, 2.0, 3.0]);
-        assert_relative_eq!(transform.rotation, rotation);
+        let local_transform = world.get::<LocalTransform>(entity).unwrap();
+        assert_relative_eq!(local_transform.translation, vector![1.0, 2.0, 3.0]);
+        assert_relative_eq!(local_transform.rotation, rotation);
     }
 
     fn schedule(

--- a/hotham/src/util.rs
+++ b/hotham/src/util.rs
@@ -58,14 +58,14 @@ pub fn get_world_with_hands(
     // Add two hands
     let left_hand = add_model_to_world("Left Hand", &models, &mut world, None).unwrap();
     {
-        let mut transform = world.get_mut::<LocalTransform>(left_hand).unwrap();
-        transform.translation = [-0.2, 1.4, 0.0].into();
+        let mut local_transform = world.get_mut::<LocalTransform>(left_hand).unwrap();
+        local_transform.translation = [-0.2, 1.4, 0.0].into();
     }
 
     let right_hand = add_model_to_world("Right Hand", &models, &mut world, None).unwrap();
     {
-        let mut transform = world.get_mut::<LocalTransform>(right_hand).unwrap();
-        transform.translation = [0.2, 1.4, 0.0].into();
+        let mut local_transform = world.get_mut::<LocalTransform>(right_hand).unwrap();
+        local_transform.translation = [0.2, 1.4, 0.0].into();
     }
 
     // Sanity check


### PR DESCRIPTION
Follow up on #291 to rename more variables for consistency. Mostly renaming `transform` to either `local_transform `or `global_transform` but also some `y_from_x` type of names for matrices (not components).