### PR TITLE
[Feature] First pass at Input API

### DIFF
--- a/examples/simple-scene/src/lib.rs
+++ b/examples/simple-scene/src/lib.rs
@@ -5,7 +5,7 @@ use hotham::{
     rapier3d::prelude::{
         ActiveCollisionTypes, ActiveEvents, ColliderBuilder, RigidBodyBuilder, RigidBodyType,
     },
-    resources::{PhysicsContext, RenderContext, XrContext},
+    resources::{InputContext, PhysicsContext, RenderContext},
     schedule_functions::physics_step,
     systems::{
         animation_system, collision_system, grabbing_system, hands::add_hand, hands_system,
@@ -98,6 +98,7 @@ fn tick(
     state: &mut State,
 ) {
     let xr_context = &mut engine.xr_context;
+    let input_context = &engine.input_context;
     let vulkan_context = &engine.vulkan_context;
     let render_context = &mut engine.render_context;
     let physics_context = &mut engine.physics_context;
@@ -120,8 +121,7 @@ fn tick(
             world,
         );
 
-        debug_system(xr_context, render_context, state);
-
+        debug_system(input_context, render_context, state);
         skinning_system(&mut queries.skins_query, world, render_context);
     }
 
@@ -137,38 +137,24 @@ fn tick(
 }
 
 #[derive(Clone, Debug, Default)]
-struct State {
-    debug_state: DebugState,
-}
-
-#[derive(Clone, Debug, Default)]
-struct DebugState {
-    button_pressed_last_frame: bool,
-}
+/// Most Hotham applications will want to keep track of some sort of state.
+/// However, this _simple_ scene doesn't have any, so this is just left here to let you know that
+/// this is something you'd probably want to do!
+struct State {}
 
 #[allow(unused)]
-fn debug_system(xr_context: &mut XrContext, render_context: &mut RenderContext, state: &mut State) {
+/// This is a simple system used to display a debug view.
+fn debug_system(
+    input_context: &InputContext,
+    render_context: &mut RenderContext,
+    state: &mut State,
+) {
     #[cfg(not(target_os = "android"))]
     return;
 
-    let input = &xr_context.input;
-    let pressed = xr::ActionInput::get(
-        &input.y_button_action,
-        &xr_context.session,
-        xr_context.input.left_hand_subaction_path,
-    )
-    .unwrap()
-    .current_state;
-
-    if state.debug_state.button_pressed_last_frame && pressed {
-        return;
-    }
-
-    if pressed {
+    if input_context.x_button_just_pressed() {
         let debug_data = &mut render_context.scene_data.debug_data;
         debug_data.x = ((debug_data.x as usize + 1) % 6) as f32;
-        println!("debug_data.x is now {}", debug_data.x);
+        println!("[HOTHAM_SIMPLE_SCENE] debug_data.x is now {}", debug_data.x);
     }
-
-    state.debug_state.button_pressed_last_frame = pressed;
 }

--- a/hotham/src/engine.rs
+++ b/hotham/src/engine.rs
@@ -1,7 +1,7 @@
 use crate::{
     resources::{
-        AudioContext, GuiContext, HapticContext, PhysicsContext, RenderContext, VulkanContext,
-        XrContext, XrContextBuilder,
+        AudioContext, GuiContext, HapticContext, InputContext, PhysicsContext, RenderContext,
+        VulkanContext, XrContext, XrContextBuilder,
     },
     HothamError, HothamResult, VIEW_TYPE,
 };
@@ -96,6 +96,7 @@ impl<'a> EngineBuilder<'a> {
             audio_context: Default::default(),
             gui_context,
             haptic_context: Default::default(),
+            input_context: Default::default(),
         }
     }
 }
@@ -123,6 +124,8 @@ pub struct Engine {
     pub gui_context: GuiContext,
     /// Haptics context
     pub haptic_context: HapticContext,
+    /// Input context
+    pub input_context: InputContext,
 }
 
 /// The result of calling `update()` on Engine.
@@ -161,6 +164,11 @@ impl Engine {
                 let current_state = self.xr_context.poll_xr_event(&mut self.event_data_buffer)?;
                 (previous_state, current_state)
             };
+
+            // If we're in the FOCUSSED state, process input.
+            if current_state == SessionState::FOCUSED {
+                self.input_context.update(&self.xr_context);
+            }
 
             // Handle any state transitions, as required.
             match (previous_state, current_state) {

--- a/hotham/src/resources/input_context.rs
+++ b/hotham/src/resources/input_context.rs
@@ -1,0 +1,119 @@
+use crate::{resources::XrContext, xr};
+
+#[derive(Debug, Default)]
+/// Context that holds input state. Allows users to query for input events without having to
+/// worry about OpenXR internals.
+///
+/// Currently only supports buttons on the Oculus Touch controllers, but will be expanded to
+/// support triggers and more.
+pub struct InputContext {
+    a_button: bool,
+    a_button_prev: bool,
+    b_button: bool,
+    b_button_prev: bool,
+    x_button: bool,
+    x_button_prev: bool,
+    y_button: bool,
+    y_button_prev: bool,
+}
+
+impl InputContext {
+    /// Get the current state of the A button
+    pub fn a_button(&self) -> bool {
+        self.a_button
+    }
+
+    /// Was the A button just pressed this frame?
+    pub fn a_button_just_pressed(&self) -> bool {
+        !self.a_button_prev & self.a_button
+    }
+
+    /// Was the A button just pressed this frame?
+    pub fn a_button_just_released(&self) -> bool {
+        self.a_button_prev & !self.a_button
+    }
+
+    /// Get the current state of the B button
+    pub fn b_button(&self) -> bool {
+        self.b_button
+    }
+
+    /// Was the B button just pressed this frame?
+    pub fn b_button_just_pressed(&self) -> bool {
+        !self.b_button_prev & self.b_button
+    }
+
+    /// Was the B button just released this frame?
+    pub fn b_button_released(&self) -> bool {
+        self.b_button_prev & !self.b_button
+    }
+
+    /// Get the current state of the X button
+    pub fn x_button(&self) -> bool {
+        self.x_button
+    }
+
+    /// Was the X button just pressed this frame?
+    pub fn x_button_just_pressed(&self) -> bool {
+        !self.x_button_prev & self.x_button
+    }
+
+    /// Was the X button just released this frame?
+    pub fn x_button_just_released(&self) -> bool {
+        self.x_button_prev & !self.x_button
+    }
+
+    /// Get the current state of the Y button
+    pub fn y_button(&self) -> bool {
+        self.y_button
+    }
+
+    /// Was the Y button just pressed this frame?
+    pub fn y_button_just_pressed(&self) -> bool {
+        !self.y_button_prev & self.y_button
+    }
+
+    /// Was the Y button just released this frame?
+    pub fn y_button_just_released(&self) -> bool {
+        self.y_button_prev & !self.y_button
+    }
+
+    /// Synchronize the context state with OpenXR. Automatically called by `Engine`
+    /// each tick.
+    pub(crate) fn update(&mut self, xr_context: &XrContext) {
+        self.a_button_prev = self.a_button;
+        self.b_button_prev = self.b_button;
+        self.x_button_prev = self.x_button;
+        self.y_button_prev = self.y_button;
+
+        let input = &xr_context.input;
+        self.a_button = xr::ActionInput::get(
+            &input.a_button_action,
+            &xr_context.session,
+            input.right_hand_subaction_path,
+        )
+        .unwrap()
+        .current_state;
+        self.b_button = xr::ActionInput::get(
+            &input.b_button_action,
+            &xr_context.session,
+            input.right_hand_subaction_path,
+        )
+        .unwrap()
+        .current_state;
+        self.x_button = xr::ActionInput::get(
+            &input.x_button_action,
+            &xr_context.session,
+            input.left_hand_subaction_path,
+        )
+        .unwrap()
+        .current_state;
+        self.y_button = xr::ActionInput::get(
+            &input.y_button_action,
+            &xr_context.session,
+            input.left_hand_subaction_path,
+        )
+        .unwrap()
+        .current_state;
+    }
+}

--- a/hotham/src/resources/mod.rs
+++ b/hotham/src/resources/mod.rs
@@ -2,6 +2,7 @@
 pub mod audio_context;
 pub mod gui_context;
 pub mod haptic_context;
+pub mod input_context;
 pub mod physics_context;
 pub mod render_context;
 pub mod vulkan_context;
@@ -10,6 +11,7 @@ pub mod xr_context;
 pub use audio_context::AudioContext;
 pub use gui_context::GuiContext;
 pub use haptic_context::HapticContext;
+pub use input_context::InputContext;
 pub use physics_context::PhysicsContext;
 pub use render_context::RenderContext;
 pub(crate) use vulkan_context::VulkanContext;


### PR DESCRIPTION
## What is this related to?
Fixes #245

## What changed?
- Added a first pass at an input API for Hotham. Currently only supports button input.
- Credit to @ickk for initially implementing this for The Station

## What is the overall impact?
- Querying for input state/changes is much easier