### PR TITLE
Refactor vulkan buffer bindings

### DIFF
--- a/hotham/src/rendering/buffer.rs
+++ b/hotham/src/rendering/buffer.rs
@@ -131,7 +131,7 @@ impl<T: Sized> Buffer<T> {
         &self,
         device: &ash::Device,
         descriptor_set: vk::DescriptorSet,
-        binding: usize,
+        binding: u32,
     ) {
         let buffer_info = vk::DescriptorBufferInfo::builder()
             .buffer(self.buffer)
@@ -147,7 +147,7 @@ impl<T: Sized> Buffer<T> {
         let write = vk::WriteDescriptorSet::builder()
             .buffer_info(std::slice::from_ref(&buffer_info))
             .dst_set(descriptor_set)
-            .dst_binding(binding as _)
+            .dst_binding(binding)
             .descriptor_type(descriptor_type);
 
         device.update_descriptor_sets(std::slice::from_ref(&write), &[]);

--- a/hotham/src/rendering/descriptors.rs
+++ b/hotham/src/rendering/descriptors.rs
@@ -3,8 +3,15 @@ use std::convert::TryInto;
 use crate::resources::{render_context::PIPELINE_DEPTH, VulkanContext};
 use ash::vk;
 
-const TEXTURE_BINDING: u32 = 4;
+pub const DRAW_DATA_BINDING: u32 = 0;
+pub const MATERIALS_BINDING: u32 = 1;
+pub const SKINS_BINDING: u32 = 2;
+pub const SCENE_DATA_BINDING: u32 = 3;
+pub const TEXTURE_BINDING: u32 = 4;
 const TEXTURE_BINDING_DESCRIPTOR_COUNT: u32 = 10_000;
+
+pub const PRIMITIVE_CULL_DATA_BINDING: u32 = 0;
+pub const CULL_PARAMS_BINDING: u32 = 1;
 
 /// A wrapper around all the various bits of descriptor functionality
 #[derive(Clone, Debug)]
@@ -121,7 +128,7 @@ unsafe fn create_descriptor_layouts(
     let graphics_bindings = [
         // Draw Data
         vk::DescriptorSetLayoutBinding {
-            binding: 0,
+            binding: DRAW_DATA_BINDING,
             descriptor_type: vk::DescriptorType::STORAGE_BUFFER,
             stage_flags: vk::ShaderStageFlags::VERTEX,
             descriptor_count: 1,
@@ -129,7 +136,7 @@ unsafe fn create_descriptor_layouts(
         },
         // Materials
         vk::DescriptorSetLayoutBinding {
-            binding: 1,
+            binding: MATERIALS_BINDING,
             descriptor_type: vk::DescriptorType::STORAGE_BUFFER,
             stage_flags: vk::ShaderStageFlags::FRAGMENT,
             descriptor_count: 1,
@@ -137,7 +144,7 @@ unsafe fn create_descriptor_layouts(
         },
         // Skins
         vk::DescriptorSetLayoutBinding {
-            binding: 2,
+            binding: SKINS_BINDING,
             descriptor_type: vk::DescriptorType::STORAGE_BUFFER,
             stage_flags: vk::ShaderStageFlags::VERTEX,
             descriptor_count: 1,
@@ -145,7 +152,7 @@ unsafe fn create_descriptor_layouts(
         },
         // Scene Data
         vk::DescriptorSetLayoutBinding {
-            binding: 3,
+            binding: SCENE_DATA_BINDING,
             descriptor_type: vk::DescriptorType::UNIFORM_BUFFER,
             stage_flags: vk::ShaderStageFlags::VERTEX | vk::ShaderStageFlags::FRAGMENT,
             descriptor_count: 1,

--- a/hotham/src/rendering/frame.rs
+++ b/hotham/src/rendering/frame.rs
@@ -5,7 +5,10 @@ use anyhow::Result;
 
 use super::{
     buffer::Buffer,
-    descriptors::Descriptors,
+    descriptors::{
+        Descriptors, CULL_PARAMS_BINDING, DRAW_DATA_BINDING, PRIMITIVE_CULL_DATA_BINDING,
+        SCENE_DATA_BINDING,
+    },
     resources::{DrawData, PrimitiveCullData},
     scene_data::SceneData,
 };
@@ -88,24 +91,24 @@ impl Frame {
             draw_data_buffer.update_descriptor_set(
                 &vulkan_context.device,
                 descriptors.sets[index],
-                0,
+                DRAW_DATA_BINDING,
             );
             scene_data_buffer.update_descriptor_set(
                 &vulkan_context.device,
                 descriptors.sets[index],
-                3,
+                SCENE_DATA_BINDING,
             );
 
             // Compute
             primitive_cull_data_buffer.update_descriptor_set(
                 &vulkan_context.device,
                 descriptors.compute_sets[index],
-                0,
+                PRIMITIVE_CULL_DATA_BINDING,
             );
             cull_params_buffer.update_descriptor_set(
                 &vulkan_context.device,
                 descriptors.compute_sets[index],
-                1,
+                CULL_PARAMS_BINDING,
             );
 
             // Add some default data to the scene buffer.

--- a/hotham/src/rendering/resources.rs
+++ b/hotham/src/rendering/resources.rs
@@ -6,8 +6,12 @@ use vulkan_context::VulkanContext;
 use crate::resources::vulkan_context;
 
 use super::{
-    buffer::Buffer, descriptors::Descriptors, image::Image, material::Material,
-    mesh_data::MeshData, vertex::Vertex,
+    buffer::Buffer,
+    descriptors::{Descriptors, MATERIALS_BINDING, SKINS_BINDING},
+    image::Image,
+    material::Material,
+    mesh_data::MeshData,
+    vertex::Vertex,
 };
 
 static VERTEX_BUFFER_SIZE: usize = 1_000_000; // TODO
@@ -64,7 +68,7 @@ impl Resources {
             MATERIAL_BUFFER_SIZE,
         );
         for set in descriptors.sets {
-            materials_buffer.update_descriptor_set(&vulkan_context.device, set, 1);
+            materials_buffer.update_descriptor_set(&vulkan_context.device, set, MATERIALS_BINDING);
         }
 
         // RESERVE index 0 for the default material, available as the material::NO_MATERIAL constant.
@@ -77,7 +81,7 @@ impl Resources {
         );
 
         for set in descriptors.sets {
-            skins_buffer.update_descriptor_set(&vulkan_context.device, set, 2);
+            skins_buffer.update_descriptor_set(&vulkan_context.device, set, SKINS_BINDING);
         }
 
         let texture_sampler = vulkan_context


### PR DESCRIPTION
Tidy up Vulkan buffer bindings a bit by giving them names instead of using magic numbers.