### PR TITLE
Fix build and tests

### DIFF
--- a/examples/crab-saber/src/components/color.rs
+++ b/examples/crab-saber/src/components/color.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, PartialEq, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub enum Color {
     Red,
     Blue,

--- a/examples/crab-saber/src/resources/game_context.rs
+++ b/examples/crab-saber/src/resources/game_context.rs
@@ -254,7 +254,7 @@ pub fn pre_spawn_cube(
         .unwrap();
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GameState {
     Init,
     MainMenu,
@@ -262,7 +262,7 @@ pub enum GameState {
     GameOver,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Song {
     pub track: MusicTrack,
     pub beat_length: Duration,

--- a/hotham-simulator/src/simulator.rs
+++ b/hotham-simulator/src/simulator.rs
@@ -145,7 +145,7 @@ pub unsafe extern "system" fn create_vulkan_instance(
         create_info.pp_enabled_extension_names,
         create_info.enabled_extension_count as usize,
     );
-    for ext in &(*xr_extensions) {
+    for ext in xr_extensions {
         enabled_extensions.push(CStr::from_ptr(*ext));
     }
 

--- a/hotham/src/asset_importer/mod.rs
+++ b/hotham/src/asset_importer/mod.rs
@@ -410,10 +410,15 @@ mod tests {
                 unsafe {
                     let material = &render_context.resources.materials_buffer.as_slice()
                         [primitive.material_id as usize];
-                    assert_eq!(material.base_color_texture_set, 0);
-                    assert_eq!(material.physical_descriptor_texture_id, 1);
-                    assert_eq!(material.normal_texture_set, 2);
-                    assert_eq!(material.occlusion_texture_set, 3);
+                    assert_eq!(
+                        (
+                            material.base_color_texture_set,
+                            material.physical_descriptor_texture_id,
+                            material.normal_texture_set,
+                            material.occlusion_texture_set
+                        ),
+                        (1, 2, 3, 4)
+                    );
                 }
             }
 

--- a/hotham/src/components/parent.rs
+++ b/hotham/src/components/parent.rs
@@ -2,5 +2,5 @@ use hecs::Entity;
 
 /// Component added to indicate that an entity has a parent
 /// Used by `update_global_transform_with_parent_system`
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Parent(pub Entity);

--- a/hotham/src/components/sound_emitter.rs
+++ b/hotham/src/components/sound_emitter.rs
@@ -26,7 +26,7 @@ impl Clone for SoundEmitter {
 }
 
 /// State of a sound
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SoundState {
     /// The sound has stopped permanently
     Stopped,

--- a/hotham/src/resources/audio_context.rs
+++ b/hotham/src/resources/audio_context.rs
@@ -27,7 +27,7 @@ pub struct AudioContext {
 }
 
 /// A music track
-#[derive(Debug, Clone, PartialEq, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct MusicTrack {
     index: Index,
 }

--- a/hotham/src/resources/render_context.rs
+++ b/hotham/src/resources/render_context.rs
@@ -415,7 +415,7 @@ impl RenderContext {
 }
 
 pub fn create_push_constant<T: Sized>(p: &T) -> &[u8] {
-    unsafe { std::slice::from_raw_parts(std::mem::transmute(p), size_of::<T>()) }
+    unsafe { std::slice::from_raw_parts(p as *const T as *const u8, size_of::<T>()) }
 }
 
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
Make main branch green again!

* There is a new version of clippy released that found some stuff to improve.
* #323 added environment maps that are automatically loaded and bumps the indices of other textures. This tripped `asset_importer::tests::test_load_models`.