### PR TITLE
Put hotham-debug-server behind optional feature named `debug_server`

### DIFF
--- a/hotham/Cargo.toml
+++ b/hotham/Cargo.toml
@@ -20,7 +20,7 @@ egui = "0.15"
 generational-arena = "0.2.8"
 gltf = {version = "1.0", features = ["KHR_lights_punctual", "KHR_materials_unlit", "names", "utils"], default-features = false}
 hecs = "0.7.7"
-hotham-debug-server = {path = "../hotham-debug-server", version = "0.2"}
+hotham-debug-server = {path = "../hotham-debug-server", version = "0.2", optional = true}
 id-arena = "2.2.1"
 image = {version = "0.24.3", default-features = false, features = ["jpeg", "png"]}
 itertools = "0.10.0"
@@ -49,3 +49,6 @@ serde_json = "1.0"
 jni = "0.19.0"
 ndk = "0.6"
 ndk-glue = "0.6"
+
+[features]
+debug_server = ["hotham-debug-server"]

--- a/hotham/src/schedule_functions/mod.rs
+++ b/hotham/src/schedule_functions/mod.rs
@@ -1,8 +1,10 @@
 #![allow(missing_docs)]
 pub mod apply_haptic_feedback;
 pub mod physics_step;
+#[cfg(feature = "debug_server")]
 pub mod sync_debug_server;
 
 pub use apply_haptic_feedback::apply_haptic_feedback;
 pub use physics_step::physics_step;
+#[cfg(feature = "debug_server")]
 pub use sync_debug_server::sync_debug_server;


### PR DESCRIPTION
Cuts down the dependency tree in the `hotham` crate from 385 to 273 dependencies. And somehow that one felt a bit too easy, since the debug server was indeed _completely_ unused.

Closes #285.