### PR TITLE
Pack joint indices and weights into two u32's

### DIFF
--- a/hotham/src/rendering/primitive.rs
+++ b/hotham/src/rendering/primitive.rs
@@ -117,11 +117,11 @@ impl Primitive {
 
         if let Some(iter) = reader.read_joints(0) {
             for t in iter.into_u16() {
-                joint_indices.push(vector![t[0] as f32, t[1] as f32, t[2] as f32, t[3] as f32]);
+                joint_indices.push(vector![t[0] as u8, t[1] as u8, t[2] as u8, t[3] as u8]);
             }
         } else {
             for _ in 0..positions.len() {
-                joint_indices.push(vector![0., 0., 0., 0.]);
+                joint_indices.push(vector![0, 0, 0, 0]);
             }
         }
 

--- a/hotham/src/rendering/vertex.rs
+++ b/hotham/src/rendering/vertex.rs
@@ -52,6 +52,7 @@ impl Vertex {
             Vector4<f32>,
         ),
     ) -> Self {
+        // Normalize weights to 0 <= w <= 255 while avoiding division with zero.
         let max_weight = t.5.max().max(f32::EPSILON);
         let weight_normalization = 255.0 / max_weight;
         Vertex::new(
@@ -59,10 +60,12 @@ impl Vertex {
             t.1,
             t.2,
             t.3,
+            // Pack indices into one u32 with one byte per index.
             (t.4[0] as u32)
                 + (t.4[1] as u32) * 256
                 + (t.4[2] as u32) * 256 * 256
                 + (t.4[3] as u32) * 256 * 256 * 256,
+            // Pack weights into one u32 with one byte per weight.
             ((t.5[0] * weight_normalization).round() as u32)
                 + ((t.5[1] * weight_normalization).round() as u32) * 256
                 + ((t.5[2] * weight_normalization).round() as u32) * 256 * 256

--- a/hotham/src/rendering/vertex.rs
+++ b/hotham/src/rendering/vertex.rs
@@ -13,10 +13,10 @@ pub struct Vertex {
     pub tangent: Vector4<f32>,
     /// First set of texture coordinates
     pub texture_coords: Vector2<f32>,
-    /// Joint indices (for skinning)
-    pub joint_indices: Vector4<f32>,
-    /// Joint weights (for skinning)
-    pub joint_weights: Vector4<f32>,
+    /// Joint indices (for skinning), one byte per index.
+    pub joint_indices: u32,
+    /// Joint weights (for skinning), one byte per weight.
+    pub joint_weights: u32,
 }
 
 impl Vertex {
@@ -26,8 +26,8 @@ impl Vertex {
         normal: Vector3<f32>,
         tangent: Vector4<f32>,
         texture_coords: Vector2<f32>,
-        joint_indices: Vector4<f32>,
-        joint_weights: Vector4<f32>,
+        joint_indices: u32,
+        joint_weights: u32,
     ) -> Self {
         Self {
             position,
@@ -48,11 +48,26 @@ impl Vertex {
             Vector3<f32>,
             Vector4<f32>,
             Vector2<f32>,
-            Vector4<f32>,
+            Vector4<u8>,
             Vector4<f32>,
         ),
     ) -> Self {
-        Vertex::new(t.0, t.1, t.2, t.3, t.4, t.5)
+        let max_weight = t.5.max().max(f32::EPSILON);
+        let weight_normalization = 255.0 / max_weight;
+        Vertex::new(
+            t.0,
+            t.1,
+            t.2,
+            t.3,
+            (t.4[0] as u32)
+                + (t.4[1] as u32) * 256
+                + (t.4[2] as u32) * 256 * 256
+                + (t.4[3] as u32) * 256 * 256 * 256,
+            ((t.5[0] * weight_normalization).round() as u32)
+                + ((t.5[1] * weight_normalization).round() as u32) * 256
+                + ((t.5[2] * weight_normalization).round() as u32) * 256 * 256
+                + ((t.5[3] * weight_normalization).round() as u32) * 256 * 256 * 256,
+        )
     }
 }
 

--- a/hotham/src/shaders/pbr.vert
+++ b/hotham/src/shaders/pbr.vert
@@ -8,8 +8,8 @@ layout (location = 0) in vec3 inPos;
 layout (location = 1) in vec3 inNormal;
 layout (location = 2) in vec4 inTangent;
 layout (location = 3) in vec2 inUV;
-layout (location = 4) in vec4 inJoint;
-layout (location = 5) in vec4 inWeight;
+layout (location = 4) in uint inJoint;
+layout (location = 5) in uint inWeight;
 
 layout (location = 0) out vec4 outGlobalPos;
 layout (location = 1) out vec2 outUV;
@@ -36,10 +36,10 @@ void main() {
     } else {
         // Mesh is skinned
         mat4 skinMatrix =
-            inWeight.x * skinsBuffer.jointMatrices[d.skinID][int(inJoint.x)] +
-            inWeight.y * skinsBuffer.jointMatrices[d.skinID][int(inJoint.y)] +
-            inWeight.z * skinsBuffer.jointMatrices[d.skinID][int(inJoint.z)] +
-            inWeight.w * skinsBuffer.jointMatrices[d.skinID][int(inJoint.w)];
+            ((inWeight) & 255)       * skinsBuffer.jointMatrices[d.skinID][(inJoint) & 255] +
+            ((inWeight >> 8) & 255)  * skinsBuffer.jointMatrices[d.skinID][(inJoint >> 8) & 255] +
+            ((inWeight >> 16) & 255) * skinsBuffer.jointMatrices[d.skinID][(inJoint >> 16) & 255] +
+            ((inWeight >> 24) & 255) * skinsBuffer.jointMatrices[d.skinID][(inJoint >> 24) & 255];
 
         outGlobalPos = d.globalFromLocal * skinMatrix * vec4(inPos, 1.0);
 

--- a/hotham/src/shaders/pbr.vert
+++ b/hotham/src/shaders/pbr.vert
@@ -35,6 +35,8 @@ void main() {
         outTBN = mat3(globalTangent, globalBiTangent, globalNormal);
     } else {
         // Mesh is skinned
+        // Shift and mask to unpack the individual indices and weights.
+        // There is no need to divide with the sum of weights because we are using homogenous coordinates.
         mat4 skinMatrix =
             ((inWeight) & 255)       * skinsBuffer.jointMatrices[d.skinID][(inJoint) & 255] +
             ((inWeight >> 8) & 255)  * skinsBuffer.jointMatrices[d.skinID][(inJoint >> 8) & 255] +


### PR DESCRIPTION
Benchmarked with `ManyVertices`:
[main.log](https://github.com/leetvr/hotham/files/9417128/main.log)
[packed-joints.log](https://github.com/leetvr/hotham/files/9417130/packed-joints.log)

Main in red, packed in green:
![image](https://user-images.githubusercontent.com/1162652/186451640-18e1841a-4673-4791-bf72-febc5b29641f.png)
![image](https://user-images.githubusercontent.com/1162652/186451730-1e150804-a0ad-46e0-8d20-d9a43e47bbcc.png)

