### PR TITLE
Rasmusgo/wait for pid in scripts

### DIFF
--- a/benchmarks/stress-test/run_on_device.sh
+++ b/benchmarks/stress-test/run_on_device.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -eux
+
+adb shell am force-stop rust.hotham_stress_test
+
+scriptdir=$(dirname -- "$(realpath -- "$0")")
+cd $scriptdir
+
+cargo apk run --release
+
+# Wait for the app to start
+for i in 1 2 3 4 5; do
+    adb shell pidof rust.hotham_stress_test && break
+    sleep 1
+done
+
+adb logcat --pid="$(adb shell pidof rust.hotham_stress_test)"

--- a/examples/crab-saber/scripts/run_on_device.sh
+++ b/examples/crab-saber/scripts/run_on_device.sh
@@ -8,4 +8,10 @@ cd $scriptdir/..
 
 cargo apk run --release
 
+# Wait for the app to start
+for i in 1 2 3 4 5; do
+    adb shell pidof rust.crab_saber && break
+    sleep 1
+done
+
 adb logcat --pid="$(adb shell pidof rust.crab_saber)"

--- a/examples/simple-scene/scripts/run_on_device.sh
+++ b/examples/simple-scene/scripts/run_on_device.sh
@@ -8,4 +8,10 @@ cd $scriptdir/..
 
 cargo apk run --release
 
+# Wait for the app to start
+for i in 1 2 3 4 5; do
+    adb shell pidof rust.simple_scene_example && break
+    sleep 1
+done
+
 adb logcat --pid="$(adb shell pidof rust.simple_scene_example)"


### PR DESCRIPTION
* Wait for app to start before running `logcat` in bash scripts.
* Add bash script for running stress test.

Tested on windows with git bash.