### PR TITLE
Profiling with puffin

### DIFF
--- a/benchmarks/stress-test/src/lib.rs
+++ b/benchmarks/stress-test/src/lib.rs
@@ -43,6 +43,8 @@ pub fn real_main() -> HothamResult<()> {
     let queries = Default::default();
     let timer = Default::default();
 
+    engine.start_puffin_server();
+
     let mut tick_props = TickProps {
         engine,
         world,

--- a/hotham/Cargo.toml
+++ b/hotham/Cargo.toml
@@ -29,6 +29,8 @@ mint = "0.5.6"
 nalgebra = {features = ["convert-mint", "serde-serialize"], version = "0.31.0"}
 oddio = "0.5"
 openxr = {features = ["loaded", "mint"], version = "0.16"}
+puffin = "0.13"
+puffin_http = "0.10"
 rapier3d = "0.14.0"
 ruzstd = "0.3"
 serde = {version = "1.0", features = ["derive"]}

--- a/hotham/src/lib.rs
+++ b/hotham/src/lib.rs
@@ -19,6 +19,7 @@ pub use engine::{Engine, EngineBuilder, TickData};
 pub use hecs;
 pub use hotham_error::HothamError;
 pub use nalgebra;
+pub use puffin;
 pub use rapier3d;
 
 /// Components are data that are used to update the simulation and interact with the external world

--- a/hotham/src/resources/render_context.rs
+++ b/hotham/src/resources/render_context.rs
@@ -171,6 +171,7 @@ impl RenderContext {
     }
 
     pub(crate) fn update_scene_data(&mut self, views: &[xr::View]) {
+        puffin::profile_function!();
         self.views = views.to_owned();
 
         // View (camera)
@@ -207,6 +208,7 @@ impl RenderContext {
 
     /// Start rendering a frame
     pub(crate) fn begin_frame(&self, vulkan_context: &VulkanContext) {
+        puffin::profile_function!();
         // Get the values we need to start the frame..
         let device = &vulkan_context.device;
         let frame = &self.frames[self.frame_index];
@@ -227,6 +229,7 @@ impl RenderContext {
     }
 
     pub(crate) fn cull_objects(&mut self, vulkan_context: &VulkanContext) {
+        puffin::profile_function!();
         let device = &vulkan_context.device;
         let frame_index = self.frame_index;
         let frame = &mut self.frames[self.frame_index];
@@ -309,6 +312,7 @@ impl RenderContext {
         vulkan_context: &VulkanContext,
         swapchain_image_index: usize,
     ) {
+        puffin::profile_function!();
         // Get the values we need to start a renderpass
         let device = &vulkan_context.device;
         let frame = &self.frames[self.frame_index];
@@ -357,6 +361,7 @@ impl RenderContext {
     }
 
     pub(crate) fn end_pbr_render_pass(&mut self, vulkan_context: &VulkanContext) {
+        puffin::profile_function!();
         let device = &vulkan_context.device;
         let frame = &self.frames[self.frame_index];
         let command_buffer = frame.command_buffer;
@@ -367,6 +372,7 @@ impl RenderContext {
 
     /// Finish rendering a frame
     pub(crate) fn end_frame(&mut self, vulkan_context: &VulkanContext) {
+        puffin::profile_function!();
         // Get the values we need to end the renderpass
         let device = &vulkan_context.device;
         let frame = &self.frames[self.frame_index];
@@ -389,6 +395,7 @@ impl RenderContext {
     }
 
     pub(crate) fn wait(&self, device: &ash::Device, frame: &Frame) {
+        puffin::profile_function!();
         let fence = frame.fence;
 
         unsafe {
@@ -406,6 +413,7 @@ impl RenderContext {
         offsets: Vec<vk::DeviceSize>,
         texture_image: &Image,
     ) -> Result<u32> {
+        puffin::profile_function!();
         vulkan_context.set_debug_name(
             vk::ObjectType::IMAGE,
             texture_image.handle.as_raw(),

--- a/hotham/src/schedule_functions/physics_step.rs
+++ b/hotham/src/schedule_functions/physics_step.rs
@@ -2,5 +2,6 @@ use crate::resources::PhysicsContext;
 
 // TODO: We may want to adjust this so that the tick time is synced with OpenXR
 pub fn physics_step(physics_context: &mut PhysicsContext) {
+    puffin::profile_function!();
     physics_context.update();
 }

--- a/hotham/src/systems/animation.rs
+++ b/hotham/src/systems/animation.rs
@@ -4,6 +4,7 @@ use hecs::{PreparedQuery, World};
 /// Animation system
 /// Walks through each AnimationController and applies the appropriate animation to its targets.
 pub fn animation_system(query: &mut PreparedQuery<&AnimationController>, world: &mut World) {
+    puffin::profile_function!();
     for (_, controller) in query.query(world).iter() {
         let blend_from = controller.blend_from;
         let blend_to = controller.blend_to;

--- a/hotham/src/systems/collision.rs
+++ b/hotham/src/systems/collision.rs
@@ -9,6 +9,7 @@ pub fn collision_system(
     world: &World,
     physics_context: &mut PhysicsContext,
 ) {
+    puffin::profile_function!();
     for (_, collider) in query.query(world).iter() {
         // Clear out any collisions from previous frames.
         collider.collisions_this_frame.clear();

--- a/hotham/src/systems/debug.rs
+++ b/hotham/src/systems/debug.rs
@@ -2,6 +2,7 @@ use crate::resources::{InputContext, RenderContext};
 
 /// A simple system used to assist with debugging the fragment shader.
 pub fn debug_system(input_context: &InputContext, render_context: &mut RenderContext) {
+    puffin::profile_function!();
     if input_context.left.x_button_just_pressed() {
         let params = &mut render_context.scene_data.params;
         params.w = 0.;

--- a/hotham/src/systems/grabbing.rs
+++ b/hotham/src/systems/grabbing.rs
@@ -13,6 +13,7 @@ pub fn grabbing_system(
     world: &mut World,
     physics_context: &mut PhysicsContext,
 ) {
+    puffin::profile_function!();
     for (_, (hand, collider)) in query.query(world).iter() {
         // Check to see if we are currently gripping
         if hand.grip_value >= 1.0 {

--- a/hotham/src/systems/hands.rs
+++ b/hotham/src/systems/hands.rs
@@ -16,6 +16,7 @@ pub fn hands_system(
     input_context: &InputContext,
     physics_context: &mut PhysicsContext,
 ) {
+    puffin::profile_function!();
     // Get the isometry of the stage
     let global_from_stage = world
         .query_mut::<With<Stage, &RigidBody>>()

--- a/hotham/src/systems/rendering.rs
+++ b/hotham/src/systems/rendering.rs
@@ -29,6 +29,7 @@ pub fn rendering_system(
     views: &[xr::View],
     swapchain_image_index: usize,
 ) {
+    puffin::profile_function!();
     unsafe {
         begin(
             query,
@@ -59,6 +60,7 @@ pub unsafe fn begin(
     views: &[xr::View],
     swapchain_image_index: usize,
 ) {
+    puffin::profile_function!();
     // First, we need to walk through each entity that contains a mesh, collect its primitives
     // and create a list of instances, indexed by primitive ID.
     //
@@ -134,6 +136,7 @@ pub unsafe fn begin(
 ///
 /// Must be between [`begin`] and [`end`]
 pub unsafe fn draw_world(vulkan_context: &VulkanContext, render_context: &mut RenderContext) {
+    puffin::profile_function!();
     // Parse through the cull buffer and record commands. This is a bit complex.
     let device = &vulkan_context.device;
     let frame = &mut render_context.frames[render_context.frame_index];
@@ -221,6 +224,7 @@ pub unsafe fn draw_world(vulkan_context: &VulkanContext, render_context: &mut Re
 ///
 /// Must be called after `begin`
 pub fn end(vulkan_context: &VulkanContext, render_context: &mut RenderContext) {
+    puffin::profile_function!();
     // OK. We're all done!
     render_context.primitive_map.clear();
     render_context.end_pbr_render_pass(vulkan_context);

--- a/hotham/src/systems/skinning.rs
+++ b/hotham/src/systems/skinning.rs
@@ -13,6 +13,7 @@ pub fn skinning_system(
     world: &mut World,
     render_context: &mut RenderContext,
 ) {
+    puffin::profile_function!();
     for (_, (skin, global_transform)) in skins_query.query(world).iter() {
         let buffer = unsafe { render_context.resources.skins_buffer.as_slice_mut() };
         let joint_matrices = &mut buffer[skin.id as usize];

--- a/hotham/src/systems/update_global_transform.rs
+++ b/hotham/src/systems/update_global_transform.rs
@@ -9,6 +9,7 @@ pub fn update_global_transform_system(
     query: &mut PreparedQuery<(&LocalTransform, &mut GlobalTransform)>,
     world: &mut World,
 ) {
+    puffin::profile_function!();
     for (_, (local_transform, global_transform)) in query.query_mut(world) {
         global_transform.0 = Matrix4::new_translation(&local_transform.translation)
             * Matrix4::from(local_transform.rotation)

--- a/hotham/src/systems/update_global_transform_with_parent.rs
+++ b/hotham/src/systems/update_global_transform_with_parent.rs
@@ -13,6 +13,7 @@ pub fn update_global_transform_with_parent_system(
     roots_query: &mut PreparedQuery<Without<Parent, &GlobalTransform>>,
     world: &mut World,
 ) {
+    puffin::profile_function!();
     // Build hierarchy
     let mut hierarchy: HashMap<Entity, Vec<Entity>> = HashMap::new();
     for (entity, parent) in parent_query.query_mut(world) {

--- a/hotham/src/systems/update_local_transform_with_rigid_body.rs
+++ b/hotham/src/systems/update_local_transform_with_rigid_body.rs
@@ -12,6 +12,7 @@ pub fn update_local_transform_with_rigid_body_system(
     world: &mut World,
     physics_context: &PhysicsContext,
 ) {
+    puffin::profile_function!();
     for (_, (rigid_body, local_transform)) in query.query_mut(world) {
         let rigid_body = &physics_context.rigid_bodies[rigid_body.handle];
         let position = rigid_body.position();


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1162652/189484171-7ba9bdd1-c62b-49f8-979f-88ff7dcd3301.png)

This PR adds [puffin ](https://github.com/EmbarkStudios/puffin) and [puffin_http](https://github.com/EmbarkStudios/puffin/tree/main/puffin_http) for profiling. This allows for remote profiling and viewing profiling data live with [puffin_viewer](https://github.com/EmbarkStudios/puffin/tree/main/puffin_viewer). This works both locally when running in desktop mode and remotely when running natively on the quest. The viewer is currently always on the desktop side but an in-game viewer ([puffin_egui](https://github.com/EmbarkStudios/puffin/tree/main/puffin_egui)) could be added later on.

Install and run the remote viewer with:
```sh
cargo install puffin_viewer
puffin_viewer --url 127.0.0.1:8585
```

Then run an application with profiling enabled. The stress-test enables profiling automatically and it is a single function call to enable profiling in any other application.

You will need to find the IP address of the quest to connect to it when profiling natively. I found it by looking at the device list in my router but there are probably better ways to do this.