### PR TITLE
Add apply_haptic_feedback as no-op to simulator

### DIFF
--- a/hotham-simulator/src/lib.rs
+++ b/hotham-simulator/src/lib.rs
@@ -151,6 +151,8 @@ pub unsafe extern "C" fn get_instance_proc_addr(
         *function = transmute::<pfn::GetActionStateFloat, _>(get_action_state_float);
     } else if name == b"xrGetActionStateBoolean" {
         *function = transmute::<pfn::GetActionStateBoolean, _>(get_action_state_boolean);
+    } else if name == b"xrApplyHapticFeedback" {
+        *function = transmute::<pfn::ApplyHapticFeedback, _>(apply_haptic_feedback);
     } else if name == b"xrEndSession" {
         *function = transmute::<pfn::EndSession, _>(end_session);
     } else {

--- a/hotham-simulator/src/simulator.rs
+++ b/hotham-simulator/src/simulator.rs
@@ -22,15 +22,15 @@ use openxr_sys::{
     ActionStateBoolean, ActionStateFloat, ActionStateGetInfo, ActionStatePose, ActionsSyncInfo,
     Duration, EnvironmentBlendMode, EventDataBuffer, EventDataSessionStateChanged, Fovf,
     FrameBeginInfo, FrameEndInfo, FrameState, FrameWaitInfo, GraphicsRequirementsVulkanKHR,
-    Instance, InstanceCreateInfo, InstanceProperties, InteractionProfileSuggestedBinding, Path,
-    Posef, Quaternionf, ReferenceSpaceCreateInfo, ReferenceSpaceType, Result, Session,
-    SessionActionSetsAttachInfo, SessionBeginInfo, SessionCreateInfo, SessionState, Space,
-    SpaceLocation, SpaceLocationFlags, StructureType, Swapchain, SwapchainCreateInfo,
-    SwapchainImageAcquireInfo, SwapchainImageBaseHeader, SwapchainImageReleaseInfo,
-    SwapchainImageVulkanKHR, SwapchainImageWaitInfo, SystemGetInfo, SystemId, SystemProperties,
-    Time, Vector3f, Version, View, ViewConfigurationType, ViewConfigurationView, ViewLocateInfo,
-    ViewState, ViewStateFlags, VulkanDeviceCreateInfoKHR, VulkanGraphicsDeviceGetInfoKHR,
-    VulkanInstanceCreateInfoKHR, FALSE, TRUE,
+    HapticActionInfo, HapticBaseHeader, Instance, InstanceCreateInfo, InstanceProperties,
+    InteractionProfileSuggestedBinding, Path, Posef, Quaternionf, ReferenceSpaceCreateInfo,
+    ReferenceSpaceType, Result, Session, SessionActionSetsAttachInfo, SessionBeginInfo,
+    SessionCreateInfo, SessionState, Space, SpaceLocation, SpaceLocationFlags, StructureType,
+    Swapchain, SwapchainCreateInfo, SwapchainImageAcquireInfo, SwapchainImageBaseHeader,
+    SwapchainImageReleaseInfo, SwapchainImageVulkanKHR, SwapchainImageWaitInfo, SystemGetInfo,
+    SystemId, SystemProperties, Time, Vector3f, Version, View, ViewConfigurationType,
+    ViewConfigurationView, ViewLocateInfo, ViewState, ViewStateFlags, VulkanDeviceCreateInfoKHR,
+    VulkanGraphicsDeviceGetInfoKHR, VulkanInstanceCreateInfoKHR, FALSE, TRUE,
 };
 use rand::random;
 use std::{
@@ -1776,6 +1776,16 @@ pub unsafe extern "system" fn get_action_state_boolean(
         last_change_time: openxr_sys::Time::from_nanos(0),
         is_active: TRUE,
     };
+    Result::SUCCESS
+}
+
+pub unsafe extern "system" fn apply_haptic_feedback(
+    _session: Session,
+    _haptic_action_info: *const HapticActionInfo,
+    _haptic_feedback: *const HapticBaseHeader,
+) -> Result {
+    /* explicit no-op, could possibly be extended with controller support in future if winit ever
+     * provides such APIs */
     Result::SUCCESS
 }
 


### PR DESCRIPTION
Fixes #350. Tested through repeatingly requesting haptic feedback while in the crab saber main menu.