### PR TITLE
Add spotlight render test

### DIFF
--- a/hotham/src/asset_importer/mod.rs
+++ b/hotham/src/asset_importer/mod.rs
@@ -81,7 +81,7 @@ pub fn load_scene_from_glb(
 }
 
 // TODO: At the moment we only support lights in the top level scene object. glTF lets us do fancier things like
-//       have lights be part of the node heirarchy, which we should definitely support, but we're not there yet.
+//       have lights be part of the node hierarchy, which we should definitely support, but we're not there yet.
 fn get_lights_from_gltf_data(document: &Document) -> Result<Vec<Light>> {
     let mut lights = Vec::new();
     for node in document

--- a/hotham/src/rendering/light.rs
+++ b/hotham/src/rendering/light.rs
@@ -31,10 +31,10 @@ pub struct Light {
 
     /// The position of the light
     pub position: Vector3<f32>,
-    /// Cosine of the angle, in radians, from centre of spotlight where falloff begins.
+    /// Cosine of the angle, in radians, from center of spotlight where falloff begins.
     pub inner_cone_cos: f32,
 
-    /// Cosine of the angle, in radians, from centre of spotlight where falloff ends.
+    /// Cosine of the angle, in radians, from center of spotlight where falloff ends.
     pub outer_cone_cos: f32,
     /// The type of the light. LIGHT_TYPE_NONE indicates to the fragment shader that this light is empty.
     pub light_type: u32,

--- a/test_assets/render_Spotlight.jpg
+++ b/test_assets/render_Spotlight.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8c60c67c7eac6ee814bfc1e691028a711b300436af84518095f258874c594e4
+size 29402

--- a/test_assets/render_Spotlight_known_good.jpg
+++ b/test_assets/render_Spotlight_known_good.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8c60c67c7eac6ee814bfc1e691028a711b300436af84518095f258874c594e4
+size 29402


### PR DESCRIPTION
Prepping for rendering in Globally Oriented Stage (GOS) space by adding a render test with a spotlight (and some refactoring and spelling fixes). These changes are rebased from #336.

![render_Spotlight](https://user-images.githubusercontent.com/1162652/191011918-4205573a-1a14-4711-b514-faa754e19c58.jpg)
