### PR TITLE
Render in globally oriented stage space

### DIFF
--- a/hotham/src/rendering/camera.rs
+++ b/hotham/src/rendering/camera.rs
@@ -6,7 +6,7 @@ use crate::util::posef_to_isometry;
 #[derive(Debug, Clone)]
 /// The Camera, or View, in a scene.
 pub struct Camera {
-    /// The camera's position in globally oriented stage space
+    /// The camera's pose in globally oriented stage space
     pub gos_from_view: Isometry3<f32>,
     /// The view matrix
     pub view_from_gos: Matrix4<f32>,
@@ -23,9 +23,9 @@ impl Default for Camera {
 }
 
 impl Camera {
-    /// Update the camera's position from an OpenXR view (stage from view)
+    /// Update the camera's position from an OpenXR view
     pub fn update(&mut self, view: &View, gos_from_stage: &Isometry3<f32>) -> Matrix4<f32> {
-        // Convert values from OpenXR format
+        // Convert values from OpenXR format and use globally oriented stage space instead of stage space
         let stage_from_view = posef_to_isometry(view.pose);
         self.gos_from_view = gos_from_stage * stage_from_view;
 
@@ -34,7 +34,7 @@ impl Camera {
     }
 
     /// Get the camera's position
-    pub fn position(&self) -> Vector4<f32> {
+    pub fn position_in_gos(&self) -> Vector4<f32> {
         let p = self.gos_from_view.translation.vector;
         vector![p[0], p[1], p[2], 0.]
     }

--- a/hotham/src/rendering/camera.rs
+++ b/hotham/src/rendering/camera.rs
@@ -6,41 +6,41 @@ use crate::util::posef_to_isometry;
 #[derive(Debug, Clone)]
 /// The Camera, or View, in a scene.
 pub struct Camera {
-    /// The camera's position in space
-    pub position: Isometry3<f32>,
+    /// The camera's position in globally oriented stage space
+    pub gos_from_view: Isometry3<f32>,
     /// The view matrix
-    pub view_matrix: Matrix4<f32>,
+    pub view_from_gos: Matrix4<f32>,
 }
 
 impl Default for Camera {
     fn default() -> Self {
         let t = Translation3::from(Vector3::zeros());
         Self {
-            position: Isometry3::from_parts(t, UnitQuaternion::identity()),
-            view_matrix: Matrix4::identity(),
+            gos_from_view: Isometry3::from_parts(t, UnitQuaternion::identity()),
+            view_from_gos: Matrix4::identity(),
         }
     }
 }
 
 impl Camera {
-    /// Update the camera's position from an OpenXR view
-    pub fn update(&mut self, view: &View) -> Matrix4<f32> {
+    /// Update the camera's position from an OpenXR view (stage from view)
+    pub fn update(&mut self, view: &View, gos_from_stage: &Isometry3<f32>) -> Matrix4<f32> {
         // Convert values from OpenXR format
-        let camera_position = posef_to_isometry(view.pose);
-        self.position = camera_position;
+        let stage_from_view = posef_to_isometry(view.pose);
+        self.gos_from_view = gos_from_stage * stage_from_view;
 
-        self.view_matrix = self.build_matrix();
-        self.view_matrix
+        self.view_from_gos = self.build_matrix();
+        self.view_from_gos
     }
 
     /// Get the camera's position
     pub fn position(&self) -> Vector4<f32> {
-        let p = self.position.translation.vector;
+        let p = self.gos_from_view.translation.vector;
         vector![p[0], p[1], p[2], 0.]
     }
 
     /// Build the camera's view matrix
     pub fn build_matrix(&self) -> Matrix4<f32> {
-        self.position.inverse().to_homogeneous()
+        self.gos_from_view.inverse().to_homogeneous()
     }
 }

--- a/hotham/src/rendering/light.rs
+++ b/hotham/src/rendering/light.rs
@@ -1,4 +1,4 @@
-use nalgebra::{UnitQuaternion, Vector3};
+use nalgebra::{Point3, UnitQuaternion, Vector3};
 use serde::{Deserialize, Serialize};
 
 /// A directional light.
@@ -30,7 +30,7 @@ pub struct Light {
     pub intensity: f32,
 
     /// The position of the light
-    pub position: Vector3<f32>,
+    pub position: Point3<f32>,
     /// Cosine of the angle, in radians, from center of spotlight where falloff begins.
     pub inner_cone_cos: f32,
 
@@ -55,7 +55,7 @@ impl Light {
         range: f32,
         intensity: f32,
         color: Vector3<f32>,
-        position: Vector3<f32>,
+        position: Point3<f32>,
         inner_cone_angle: f32,
         outer_cone_angle: f32,
     ) -> Self {
@@ -84,7 +84,7 @@ impl Light {
 
     /// Create a new point light
     pub fn new_point(
-        position: Vector3<f32>,
+        position: Point3<f32>,
         range: f32,
         intensity: f32,
         color: Vector3<f32>,

--- a/hotham/src/rendering/resources.rs
+++ b/hotham/src/rendering/resources.rs
@@ -201,10 +201,10 @@ fn load_ibl_textures(
 #[repr(C, align(16))]
 pub struct DrawData {
     /// The transform of the parent mesh
-    pub global_from_local: Matrix4<f32>,
+    pub gos_from_local: Matrix4<f32>,
     /// The inverse of the transform of the parent mesh
     /// Transform normals by multiplying with the matrix on the right hand side
-    pub local_from_global: Matrix4<f32>,
+    pub local_from_gos: Matrix4<f32>,
     /// The ID of the material to use.
     pub material_id: u32,
     /// An optional skin to use.

--- a/hotham/src/resources/render_context.rs
+++ b/hotham/src/resources/render_context.rs
@@ -197,7 +197,10 @@ impl RenderContext {
             Frustum::from(fov_right).projection(near) * view_matrices[1],
         ];
 
-        self.scene_data.camera_position = [self.cameras[0].position(), self.cameras[1].position()];
+        self.scene_data.camera_position = [
+            self.cameras[0].position_in_gos(),
+            self.cameras[1].position_in_gos(),
+        ];
 
         unsafe {
             let scene_data = &mut self.frames[self.frame_index]

--- a/hotham/src/resources/render_context.rs
+++ b/hotham/src/resources/render_context.rs
@@ -208,9 +208,7 @@ impl RenderContext {
             scene_data.params = self.scene_data.params;
             scene_data.lights = self.scene_data.lights;
             for light in &mut scene_data.lights {
-                light.position = gos_from_global
-                    .transform_point(&light.position.into())
-                    .coords;
+                light.position = gos_from_global.transform_point(&light.position);
                 light.direction = gos_from_global.transform_vector(&light.direction);
             }
         }

--- a/hotham/src/resources/render_context.rs
+++ b/hotham/src/resources/render_context.rs
@@ -33,7 +33,7 @@ use crate::{
 };
 use anyhow::Result;
 use ash::vk::{self, Handle};
-use nalgebra::{Matrix4, RowVector4, Vector4};
+use nalgebra::{Isometry3, Matrix4, RowVector4, Vector4};
 use openxr as xr;
 use vk_shader_macros::include_glsl;
 
@@ -170,7 +170,12 @@ impl RenderContext {
         )
     }
 
-    pub(crate) fn update_scene_data(&mut self, views: &[xr::View]) {
+    pub(crate) fn update_scene_data(
+        &mut self,
+        views: &[xr::View],
+        gos_from_global: &Isometry3<f32>,
+        gos_from_stage: &Isometry3<f32>,
+    ) {
         self.views = views.to_owned();
 
         // View (camera)
@@ -178,7 +183,7 @@ impl RenderContext {
             .cameras
             .iter_mut()
             .enumerate()
-            .map(|(n, c)| c.update(&views[n]))
+            .map(|(n, c)| c.update(&views[n], gos_from_stage))
             .collect::<Vec<_>>();
 
         // Projection
@@ -202,6 +207,12 @@ impl RenderContext {
             scene_data.view_projection = self.scene_data.view_projection;
             scene_data.params = self.scene_data.params;
             scene_data.lights = self.scene_data.lights;
+            for light in &mut scene_data.lights {
+                light.position = gos_from_global
+                    .transform_point(&light.position.into())
+                    .coords;
+                light.direction = gos_from_global.transform_vector(&light.direction);
+            }
         }
     }
 
@@ -437,7 +448,7 @@ pub(crate) struct InstancedPrimitive {
 }
 
 pub(crate) struct Instance {
-    pub(crate) global_from_local: Matrix4<f32>,
+    pub(crate) gos_from_local: Matrix4<f32>,
     pub(crate) bounding_sphere: Vector4<f32>,
     pub(crate) skin_id: u32,
 }

--- a/hotham/src/shaders/common.glsl
+++ b/hotham/src/shaders/common.glsl
@@ -6,8 +6,8 @@
 #define MAX_JOINTS 64
 
 struct DrawData {
-    mat4 globalFromLocal;
-    mat4 localFromGlobal;
+    mat4 gosFromLocal;
+    mat4 localFromGos;
     uint materialID;
     uint skinID;
 };

--- a/hotham/src/shaders/pbr.frag
+++ b/hotham/src/shaders/pbr.frag
@@ -7,7 +7,7 @@
 #include "brdf.glsl"
 
 // Inputs
-layout (location = 0) in vec3 inGlobalPos;
+layout (location = 0) in vec3 inGosPos;
 layout (location = 1) in vec2 inUV;
 layout (location = 2) flat in uint inMaterialID;
 layout (location = 3) in vec3 inNormal;

--- a/hotham/src/shaders/pbr.glsl
+++ b/hotham/src/shaders/pbr.glsl
@@ -68,14 +68,14 @@ vec3 getNormal(uint normalTextureID) {
     // We compute the tangents on the fly because it is faster, presumably because it saves bandwidth.
     // See http://www.thetenthplanet.de/archives/1180 for an explanation of how this works
     // and a little bit about why it is better than using precomputed tangents.
-    // Note however that we are using a slightly different formulation with global coordinates
-    // instead of view coordinates and we rely on the UV map not being too distorted.
-    vec3 dGlobalPosDx = dFdx(inGlobalPos);
-    vec3 dGlobalPosDy = dFdy(inGlobalPos);
+    // Note however that we are using a slightly different formulation with coordinates in
+    // globally oriented stage space instead of view space and we rely on the UV map not being too distorted.
+    vec3 dGosPosDx = dFdx(inGosPos);
+    vec3 dGosPosDy = dFdy(inGosPos);
     vec2 dUvDx = dFdx(inUV);
     vec2 dUvDy = dFdy(inUV);
 
-    vec3 T = normalize(dGlobalPosDx * dUvDy.t - dGlobalPosDy * dUvDx.t);
+    vec3 T = normalize(dGosPosDx * dUvDy.t - dGosPosDy * dUvDx.t);
     vec3 B = normalize(cross(N, T));
     mat3 TBN = mat3(T, B, N);
 
@@ -116,7 +116,7 @@ vec3 getLightContribution(MaterialInfo materialInfo, vec3 n, vec3 v, float NdotV
     // Get a vector between this point and the light.
     vec3 pointToLight;
     if (light.type != LightType_Directional) {
-        pointToLight = light.position - inGlobalPos;
+        pointToLight = light.position - inGosPos;
     } else {
         pointToLight = -light.direction;
     }
@@ -176,7 +176,7 @@ vec3 getPBRMetallicRoughnessColor(Material material, vec4 baseColor) {
     vec3 specularColor = mix(f0, baseColor.rgb, metalness);
 
     // Get the view vector - from surface point to camera
-    vec3 v = normalize(sceneData.cameraPosition[gl_ViewIndex].xyz - inGlobalPos);
+    vec3 v = normalize(sceneData.cameraPosition[gl_ViewIndex].xyz - inGosPos);
 
     // Get the normal
     vec3 n = getNormal(material.normalTextureID);

--- a/hotham/src/shaders/pbr.vert
+++ b/hotham/src/shaders/pbr.vert
@@ -10,7 +10,7 @@ layout (location = 2) in vec2 inUV;
 layout (location = 3) in uint inJoint;
 layout (location = 4) in uint inWeight;
 
-layout (location = 0) out vec4 outGlobalPos;
+layout (location = 0) out vec4 outGosPos;
 layout (location = 1) out vec2 outUV;
 layout (location = 2) flat out uint outMaterialID;
 layout (location = 3) out vec3 outNormal;
@@ -24,8 +24,8 @@ void main() {
 
     if (d.skinID == NOT_PRESENT) {
         // Mesh has no skin
-        outGlobalPos = d.globalFromLocal * vec4(inPos, 1.0);
-        outNormal = normalize(inNormal * mat3(d.localFromGlobal));
+        outGosPos = d.gosFromLocal * vec4(inPos, 1.0);
+        outNormal = normalize(inNormal * mat3(d.localFromGos));
     } else {
         // Mesh is skinned
         // Shift and mask to unpack the individual indices and weights.
@@ -36,11 +36,11 @@ void main() {
             ((inWeight >> 16) & 255) * skinsBuffer.jointMatrices[d.skinID][(inJoint >> 16) & 255] +
             ((inWeight >> 24) & 255) * skinsBuffer.jointMatrices[d.skinID][(inJoint >> 24) & 255];
 
-        outGlobalPos = d.globalFromLocal * skinMatrix * vec4(inPos, 1.0);
-        outNormal = normalize(mat3(skinMatrix) * inNormal * mat3(d.localFromGlobal));
+        outGosPos = d.gosFromLocal * skinMatrix * vec4(inPos, 1.0);
+        outNormal = normalize(mat3(skinMatrix) * inNormal * mat3(d.localFromGos));
     }
 
     outUV = inUV;
     outMaterialID = d.materialID;
-    gl_Position = sceneData.viewProjection[gl_ViewIndex] * outGlobalPos;
+    gl_Position = sceneData.viewProjection[gl_ViewIndex] * outGosPos;
 }

--- a/hotham/src/systems/mod.rs
+++ b/hotham/src/systems/mod.rs
@@ -23,7 +23,7 @@ pub use hands::hands_system;
 pub use pointers::pointers_system;
 pub use rendering::rendering_system;
 pub use skinning::skinning_system;
-pub use stage::{add_stage, update_views_with_stage_transform};
+pub use stage::add_stage;
 pub use update_global_transform::update_global_transform_system;
 pub use update_global_transform_with_parent::update_global_transform_with_parent_system;
 pub use update_local_transform_with_rigid_body::update_local_transform_with_rigid_body_system;

--- a/hotham/src/systems/rendering.rs
+++ b/hotham/src/systems/rendering.rs
@@ -314,7 +314,6 @@ mod tests {
             &mut world,
             &physics_context,
         );
-        update_global_transform_system(&mut Default::default(), &mut world);
 
         // Set views
         let rotation: mint::Quaternion<f32> =

--- a/hotham/src/systems/rendering.rs
+++ b/hotham/src/systems/rendering.rs
@@ -236,17 +236,23 @@ mod tests {
     use ash::vk;
     use ash::vk::Handle;
     use image::{codecs::jpeg::JpegEncoder, DynamicImage, RgbaImage};
-    use nalgebra::UnitQuaternion;
+    use nalgebra::{Translation3, UnitQuaternion, Vector3};
     use openxr::{Fovf, Quaternionf, Vector3f};
+    use rapier3d::prelude::Isometry;
+    use update_local_transform_with_rigid_body::update_local_transform_with_rigid_body_system;
 
     use crate::{
         asset_importer,
+        components::RigidBody,
         rendering::{
             image::Image, legacy_buffer::Buffer, light::Light, scene_data, swapchain::SwapchainInfo,
         },
-        resources::RenderContext,
-        systems::{update_global_transform_system, update_global_transform_with_parent_system},
-        util::get_from_device_memory,
+        resources::{PhysicsContext, RenderContext},
+        systems::{
+            add_stage, update_global_transform_system, update_global_transform_with_parent_system,
+            update_local_transform_with_rigid_body,
+        },
+        util::{get_from_device_memory, isometry_to_posef, posef_to_isometry},
         COLOR_FORMAT,
     };
 
@@ -278,12 +284,28 @@ mod tests {
 
         let mut render_context =
             RenderContext::new_from_swapchain_info(&vulkan_context, &swapchain).unwrap();
+        let mut physics_context = PhysicsContext::default();
 
         let gltf_data: Vec<&[u8]> = vec![include_bytes!("../../../test_assets/damaged_helmet.glb")];
         let mut models =
             asset_importer::load_models_from_glb(&gltf_data, &vulkan_context, &mut render_context)
                 .unwrap();
         let (_, mut world) = models.drain().next().unwrap();
+
+        // Add stage transform
+        let global_from_stage = Isometry::from_parts(
+            Translation3::new(0.1, 0.2, 0.3),
+            UnitQuaternion::from_scaled_axis(Vector3::y() * (std::f32::consts::TAU * 0.1)),
+        );
+        let stage_entity = add_stage(&mut world, &mut physics_context);
+        physics_context.rigid_bodies[world.get_mut::<RigidBody>(stage_entity).unwrap().handle]
+            .set_position(global_from_stage, true);
+        update_local_transform_with_rigid_body_system(
+            &mut Default::default(),
+            &mut world,
+            &physics_context,
+        );
+        update_global_transform_system(&mut Default::default(), &mut world);
 
         // Set views
         let rotation: mint::Quaternion<f32> =
@@ -305,7 +327,13 @@ mod tests {
                 angle_right: 45.0_f32.to_radians(),
             },
         };
-        let views = vec![view.clone(), view];
+        let mut views = vec![view.clone(), view];
+
+        // Compensate stage transform by adjusting the views
+        for view in &mut views {
+            view.pose =
+                isometry_to_posef(global_from_stage.inverse() * posef_to_isometry(view.pose));
+        }
 
         let params = vec![
             (

--- a/hotham/src/systems/stage.rs
+++ b/hotham/src/systems/stage.rs
@@ -1,10 +1,12 @@
+use hecs::With;
+use nalgebra::Isometry3;
+
 use crate::{
     components::{GlobalTransform, LocalTransform, RigidBody, Stage},
-    hecs::{Entity, With, World},
+    hecs::{Entity, World},
     rapier3d::prelude::RigidBodyBuilder,
     resources::PhysicsContext,
-    util::{isometry_to_posef, matrix_to_isometry, posef_to_isometry},
-    xr,
+    util::matrix_to_isometry,
 };
 
 /// Setup Stage entities to track player's frame of reference in global space
@@ -24,19 +26,13 @@ pub fn add_stage(world: &mut World, physics_context: &mut PhysicsContext) -> Ent
     ))
 }
 
-/// Update player's views to take into account the current position of the Stage in global space
-///
-/// Must happen each tick after parent transforms have been updated.
-pub fn update_views_with_stage_transform(world: &mut World, views: &mut [xr::View]) {
-    let stage_isometry = world
+/// Get the transform of the stage in global space.
+pub fn get_global_from_stage(world: &mut World) -> Isometry3<f32> {
+    // Get the stage transform
+    world
         .query_mut::<With<Stage, &GlobalTransform>>()
         .into_iter()
         .next()
-        .map(|(_, global_transform)| matrix_to_isometry(global_transform.0));
-
-    if let Some(stage_isometry) = stage_isometry {
-        for view in views {
-            view.pose = isometry_to_posef(stage_isometry * posef_to_isometry(view.pose));
-        }
-    }
+        .map(|(_, global_transform)| matrix_to_isometry(global_transform.0))
+        .unwrap_or_else(Isometry3::<_>::identity)
 }

--- a/test_assets/render_Diffuse.jpg
+++ b/test_assets/render_Diffuse.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e63bc6fa3b417ed1e0f7738ad8689411725027f598562b0dda5b810d40d17c62
-size 46345
+oid sha256:8f5ebfc23d50a627d9ef237b7668a2cf003af39426570cf80e1398195d457b01
+size 46321

--- a/test_assets/render_Diffuse_known_good.jpg
+++ b/test_assets/render_Diffuse_known_good.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e63bc6fa3b417ed1e0f7738ad8689411725027f598562b0dda5b810d40d17c62
-size 46345
+oid sha256:8f5ebfc23d50a627d9ef237b7668a2cf003af39426570cf80e1398195d457b01
+size 46321

--- a/test_assets/render_Full.jpg
+++ b/test_assets/render_Full.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b4755173054754001c1332adf38c1ad85f6c639ced360edb1243fb4262bdac90
+oid sha256:aa9130a1c82580ed7651d7c08e403be432708c9fd14f365f7604dceecd835d49
 size 45564

--- a/test_assets/render_Full_known_good.jpg
+++ b/test_assets/render_Full_known_good.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b4755173054754001c1332adf38c1ad85f6c639ced360edb1243fb4262bdac90
+oid sha256:aa9130a1c82580ed7651d7c08e403be432708c9fd14f365f7604dceecd835d49
 size 45564

--- a/test_assets/render_No_IBL.jpg
+++ b/test_assets/render_No_IBL.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4d7a638b55335f1b5db31fcaebc09c0a227f26780a2773f1b1bb7041b39ef903
-size 24233
+oid sha256:0ec5ee6148e065ace1fa198f16d662bb7915d69642ce59f4781f4eacc30b69ea
+size 24235

--- a/test_assets/render_No_IBL_known_good.jpg
+++ b/test_assets/render_No_IBL_known_good.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4d7a638b55335f1b5db31fcaebc09c0a227f26780a2773f1b1bb7041b39ef903
-size 24233
+oid sha256:0ec5ee6148e065ace1fa198f16d662bb7915d69642ce59f4781f4eacc30b69ea
+size 24235

--- a/test_assets/render_Normals.jpg
+++ b/test_assets/render_Normals.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9984e7a9fbd9dff5a401360247fd49d41056d02d5f6ba9b568ea0965eb8f7119
-size 41973
+oid sha256:a08c3fbfd6eee9414668ed0974273b4f28b0d845c8a151f455bd59e9d9320bbc
+size 41985

--- a/test_assets/render_Normals_known_good.jpg
+++ b/test_assets/render_Normals_known_good.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9984e7a9fbd9dff5a401360247fd49d41056d02d5f6ba9b568ea0965eb8f7119
-size 41973
+oid sha256:a08c3fbfd6eee9414668ed0974273b4f28b0d845c8a151f455bd59e9d9320bbc
+size 41985

--- a/test_assets/render_Spotlight.jpg
+++ b/test_assets/render_Spotlight.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f8c60c67c7eac6ee814bfc1e691028a711b300436af84518095f258874c594e4
-size 29402
+oid sha256:496b33d005ebb1f1105a35ecaf95c04e35c6c87728a5778b27c86fe8f046fc65
+size 29405

--- a/test_assets/render_Spotlight_known_good.jpg
+++ b/test_assets/render_Spotlight_known_good.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f8c60c67c7eac6ee814bfc1e691028a711b300436af84518095f258874c594e4
-size 29402
+oid sha256:496b33d005ebb1f1105a35ecaf95c04e35c6c87728a5778b27c86fe8f046fc65
+size 29405


### PR DESCRIPTION
This replaces #336.

The Globally Oriented Stage (GOS) space is global space translated so that the origin coincides with the origin of stage space. Using GOS instead of global space keeps the values of vertex positions small for vertices close to the player. This makes it less risky to use half precision floats. The winning argument to use GOS over stage space for rendering was that environment maps (eg. for image based lighting) still works as expected because the axis directions are the same as in global space.