### PR TITLE
[Simulator] Clean up Vulkan validation warnings

### DIFF
--- a/hotham/src/rendering/descriptors.rs
+++ b/hotham/src/rendering/descriptors.rs
@@ -111,11 +111,6 @@ unsafe fn allocate_descriptor_sets(
     pool: vk::DescriptorPool,
     layout: vk::DescriptorSetLayout,
 ) -> [vk::DescriptorSet; PIPELINE_DEPTH] {
-    let mut descriptor_counts = vk::DescriptorSetVariableDescriptorCountAllocateInfo::builder()
-        .descriptor_counts(&[
-            TEXTURE_BINDING_DESCRIPTOR_COUNT,
-            TEXTURE_BINDING_DESCRIPTOR_COUNT,
-        ]);
     let layouts = [layout; PIPELINE_DEPTH];
 
     vulkan_context
@@ -123,8 +118,7 @@ unsafe fn allocate_descriptor_sets(
         .allocate_descriptor_sets(
             &vk::DescriptorSetAllocateInfo::builder()
                 .descriptor_pool(pool)
-                .set_layouts(&layouts)
-                .push_next(&mut descriptor_counts),
+                .set_layouts(&layouts),
         )
         .unwrap()
         .as_slice()
@@ -225,9 +219,8 @@ unsafe fn create_descriptor_layouts(
         },
     ];
 
-    let flags = vk::DescriptorBindingFlags::PARTIALLY_BOUND
-        | vk::DescriptorBindingFlags::VARIABLE_DESCRIPTOR_COUNT
-        | vk::DescriptorBindingFlags::UPDATE_AFTER_BIND;
+    let flags =
+        vk::DescriptorBindingFlags::PARTIALLY_BOUND | vk::DescriptorBindingFlags::UPDATE_AFTER_BIND;
 
     let descriptor_flags = [
         vk::DescriptorBindingFlags::empty(),

--- a/hotham/src/rendering/vertex.rs
+++ b/hotham/src/rendering/vertex.rs
@@ -95,14 +95,14 @@ impl Vertex {
         let joint_indices = vk::VertexInputAttributeDescription::builder()
             .binding(0)
             .location(3)
-            .format(vk::Format::R32G32B32A32_SFLOAT)
+            .format(vk::Format::R32_UINT)
             .offset(memoffset::offset_of!(Vertex, joint_indices) as _)
             .build();
 
         let joint_weights = vk::VertexInputAttributeDescription::builder()
             .binding(0)
             .location(4)
-            .format(vk::Format::R32G32B32A32_SFLOAT)
+            .format(vk::Format::R32_UINT)
             .offset(memoffset::offset_of!(Vertex, joint_weights) as _)
             .build();
 


### PR DESCRIPTION
Fixes #316

- Since we don't actually use variable descriptor counts, we just get rid of them
- Some vertex attributes were not updated correctly

## What is this related to?

## What changed?

## What is the overall impact?
