### PR TITLE
Import colliders from glTF

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -22,6 +22,29 @@
 		},
 		{
 			"type": "cargo",
+			"command": "test",
+			"args": [
+				"-p",
+				"hotham",
+				"--lib",
+				"--",
+				"asset_importer::tests::test_load_model_with_colliders",
+				"--nocapture",
+			],
+			"env": {
+				"RUST_BACKTRACE": "1"
+			},
+			"problemMatcher": [
+				"$rustc"
+			],
+			"label": "Run individual Hotham test",
+			"group": {
+				"kind": "test",
+				"isDefault": true
+			}
+		},
+		{
+			"type": "cargo",
 			"command": "run",
 			"args": [
 				"--bin",
@@ -57,7 +80,7 @@
 			"label": "Run Hotham simple scene on the simulator",
 			"group": {
 				"kind": "test",
-				"isDefault": true
+				"isDefault": false
 			}
 		}
 	]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,14 @@ members = ["hotham", "hotham-simulator", "examples/simple-scene", "examples/crab
 [profile.dev.package.rapier3d]
 opt-level = 3
 
-[profile.dev.package.base64]
+[profile.dev.package.parry3d]
+opt-level = 3
+
+# Make performance critical packages compile with optimizations
+[profile.dev.package.nalgebra]
+opt-level = 3
+
+[profile.dev.package."base64"]
 opt-level = 3
 
 [profile.dev.package.gltf]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,10 @@ opt-level = 3
 [profile.dev.package.parry3d]
 opt-level = 3
 
-# Make performance critical packages compile with optimizations
 [profile.dev.package.nalgebra]
 opt-level = 3
 
-[profile.dev.package."base64"]
+[profile.dev.package.base64]
 opt-level = 3
 
 [profile.dev.package.gltf]

--- a/benchmarks/stress-test/src/lib.rs
+++ b/benchmarks/stress-test/src/lib.rs
@@ -17,7 +17,7 @@ use hotham::{
         primitive::{calculate_bounding_sphere, Primitive},
         vertex::Vertex,
     },
-    resources::RenderContext,
+    resources::{PhysicsContext, RenderContext},
     schedule_functions::physics_step,
     systems::{
         animation_system, collision_system, debug::debug_system, grabbing_system, hands_system,
@@ -118,18 +118,23 @@ pub enum StressTest {
 fn init(engine: &mut Engine, test: &StressTest) -> (World, HashMap<String, World>) {
     let render_context = &mut engine.render_context;
     let vulkan_context = &mut engine.vulkan_context;
+    let physics_context = &mut engine.physics_context;
     let mut world = World::default();
 
     let models = match test {
         StressTest::ManyCubes => {
             let glb_buffers: Vec<&[u8]> = vec![include_bytes!("../../../test_assets/cube.glb")];
-            let models =
-                asset_importer::load_models_from_glb(&glb_buffers, vulkan_context, render_context)
-                    .unwrap();
+            let models = asset_importer::load_models_from_glb(
+                &glb_buffers,
+                vulkan_context,
+                render_context,
+                physics_context,
+            )
+            .unwrap();
 
             let resolution = 34; // 42,875 cubes
 
-            setup_cubes(&mut world, resolution, &models);
+            setup_cubes(&mut world, resolution, &models, physics_context);
 
             models
         }
@@ -137,11 +142,22 @@ fn init(engine: &mut Engine, test: &StressTest) -> (World, HashMap<String, World
             let glb_buffers: Vec<&[u8]> = vec![include_bytes!(
                 "../../../test_assets/culling_stress_test.glb"
             )];
-            let models =
-                asset_importer::load_models_from_glb(&glb_buffers, vulkan_context, render_context)
-                    .unwrap();
+            let models = asset_importer::load_models_from_glb(
+                &glb_buffers,
+                vulkan_context,
+                render_context,
+                physics_context,
+            )
+            .unwrap();
 
-            add_model_to_world("Asteroid and Debris", &models, &mut world, None).unwrap();
+            add_model_to_world(
+                "Asteroid and Debris",
+                &models,
+                &mut world,
+                physics_context,
+                None,
+            )
+            .unwrap();
             models
         }
         StressTest::ManyHelmets => {
@@ -152,13 +168,23 @@ fn init(engine: &mut Engine, test: &StressTest) -> (World, HashMap<String, World
             #[cfg(not(target_os = "android"))]
             let glb_buffers: Vec<&[u8]> =
                 vec![include_bytes!("../../../test_assets/damaged_helmet.glb")];
-            let models =
-                asset_importer::load_models_from_glb(&glb_buffers, vulkan_context, render_context)
-                    .unwrap();
+            let models = asset_importer::load_models_from_glb(
+                &glb_buffers,
+                vulkan_context,
+                render_context,
+                physics_context,
+            )
+            .unwrap();
 
             for _ in 0..20 {
-                let e = add_model_to_world("Damaged Helmet", &models, &mut world, None)
-                    .expect("Could not find cube?");
+                let e = add_model_to_world(
+                    "Damaged Helmet",
+                    &models,
+                    &mut world,
+                    physics_context,
+                    None,
+                )
+                .expect("Could not find cube?");
                 let mut t = world.get_mut::<LocalTransform>(e).unwrap();
                 t.rotation = UnitQuaternion::from_axis_angle(
                     &Vector3::x_axis(),
@@ -174,11 +200,15 @@ fn init(engine: &mut Engine, test: &StressTest) -> (World, HashMap<String, World
         StressTest::Sponza => {
             let file = std::fs::read("test_assets/sponza.glb").unwrap();
             let glb_buffers: Vec<&[u8]> = vec![&file];
-            let models =
-                asset_importer::load_models_from_glb(&glb_buffers, vulkan_context, render_context)
-                    .unwrap();
+            let models = asset_importer::load_models_from_glb(
+                &glb_buffers,
+                vulkan_context,
+                render_context,
+                physics_context,
+            )
+            .unwrap();
             for name in models.keys() {
-                add_model_to_world(name, &models, &mut world, None);
+                add_model_to_world(name, &models, &mut world, physics_context, None);
             }
             models
         }
@@ -190,11 +220,15 @@ fn init(engine: &mut Engine, test: &StressTest) -> (World, HashMap<String, World
             #[cfg(not(target_os = "android"))]
             let glb_buffers: Vec<&[u8]> = vec![include_bytes!("../../../test_assets/ibl_test.glb")];
 
-            let models =
-                asset_importer::load_models_from_glb(&glb_buffers, vulkan_context, render_context)
-                    .unwrap();
+            let models = asset_importer::load_models_from_glb(
+                &glb_buffers,
+                vulkan_context,
+                render_context,
+                physics_context,
+            )
+            .unwrap();
             for name in models.keys() {
-                add_model_to_world(name, &models, &mut world, None);
+                add_model_to_world(name, &models, &mut world, physics_context, None);
             }
             models
         }
@@ -203,11 +237,15 @@ fn init(engine: &mut Engine, test: &StressTest) -> (World, HashMap<String, World
                 "../../../test_assets/normal_tangent_test.glb"
             )];
 
-            let models =
-                asset_importer::load_models_from_glb(&glb_buffers, vulkan_context, render_context)
-                    .unwrap();
+            let models = asset_importer::load_models_from_glb(
+                &glb_buffers,
+                vulkan_context,
+                render_context,
+                physics_context,
+            )
+            .unwrap();
             for name in models.keys() {
-                add_model_to_world(name, &models, &mut world, None);
+                add_model_to_world(name, &models, &mut world, physics_context, None);
             }
 
             let scene_data = &mut render_context.scene_data;
@@ -272,7 +310,9 @@ fn tick(tick_props: &mut TickProps, tick_data: TickData) {
 
         match &tick_props.test {
             // StressTest::ManyCubes => rotate_models(world, timer.total_time().as_secs_f32()),
-            StressTest::ManyHelmets => model_system(world, models, timer, "Damaged Helmet"),
+            StressTest::ManyHelmets => {
+                model_system(world, models, timer, "Damaged Helmet", physics_context)
+            }
             StressTest::ManyVertices => subdivide_mesh_system(world, render_context, timer),
             _ => {}
         }
@@ -320,9 +360,11 @@ fn model_system(
     models: &HashMap<String, World>,
     timer: &mut Timer,
     model_name: &str,
+    physics_context: &mut PhysicsContext,
 ) {
     if timer.tick() {
-        add_model_to_world(model_name, models, world, None).expect("Could not find object?");
+        add_model_to_world(model_name, models, world, physics_context, None)
+            .expect("Could not find object?");
         rearrange_models(world);
     }
 

--- a/benchmarks/stress-test/src/systems/cube.rs
+++ b/benchmarks/stress-test/src/systems/cube.rs
@@ -3,9 +3,15 @@ use hotham::{
     components::LocalTransform,
     hecs::World,
     nalgebra::Vector3,
+    resources::PhysicsContext,
 };
 
-pub fn setup_cubes(world: &mut World, resolution: usize, models: &Models) {
+pub fn setup_cubes(
+    world: &mut World,
+    resolution: usize,
+    models: &Models,
+    physics_context: &mut PhysicsContext,
+) {
     let step = 2. / resolution as f32;
     let scale_factor = 3.;
     let scale = Vector3::repeat(step / scale_factor);
@@ -15,7 +21,7 @@ pub fn setup_cubes(world: &mut World, resolution: usize, models: &Models) {
     for floor in 0..resolution {
         for row in 0..resolution {
             for column in 0..resolution {
-                let c = add_model_to_world("Cube", models, world, None).unwrap();
+                let c = add_model_to_world("Cube", models, world, physics_context, None).unwrap();
                 let mut t = world.get_mut::<LocalTransform>(c).unwrap();
                 t.scale = scale;
                 t.translation.y = floor as f32 / scale_factor;

--- a/examples/crab-saber/src/resources/game_context.rs
+++ b/examples/crab-saber/src/resources/game_context.rs
@@ -61,12 +61,16 @@ impl GameContext {
         let gui_context = &engine.gui_context;
 
         let glb_buffers: Vec<&[u8]> = vec![include_bytes!("../../assets/crab_saber.glb")];
-        let models =
-            asset_importer::load_models_from_glb(&glb_buffers, vulkan_context, render_context)
-                .expect("Unable to load models!");
+        let models = asset_importer::load_models_from_glb(
+            &glb_buffers,
+            vulkan_context,
+            render_context,
+            physics_context,
+        )
+        .expect("Unable to load models!");
 
         // Add the environment models
-        add_environment(&models, world);
+        add_environment(&models, world, physics_context);
 
         // Add sabers
         let sabers = [Color::Blue, Color::Red]
@@ -78,7 +82,7 @@ impl GameContext {
         }
 
         // Add a pointer to let the player interact with the UI
-        let pointer = add_pointer(&models, world);
+        let pointer = add_pointer(&models, world, physics_context);
 
         // Add a "backstop" collider to detect when a cube was missed
         let backstop = add_backstop(world, physics_context);
@@ -154,8 +158,12 @@ fn add_backstop(
     world.spawn((Collider::new(handle),))
 }
 
-fn add_pointer(models: &std::collections::HashMap<String, World>, world: &mut World) -> Entity {
-    let pointer = add_model_to_world("Blue Pointer", models, world, None).unwrap();
+fn add_pointer(
+    models: &std::collections::HashMap<String, World>,
+    world: &mut World,
+    physics_context: &mut PhysicsContext,
+) -> Entity {
+    let pointer = add_model_to_world("Blue Pointer", models, world, physics_context, None).unwrap();
 
     world
         .insert_one(
@@ -170,9 +178,13 @@ fn add_pointer(models: &std::collections::HashMap<String, World>, world: &mut Wo
     pointer
 }
 
-fn add_environment(models: &std::collections::HashMap<String, World>, world: &mut World) {
-    add_model_to_world("Environment", models, world, None);
-    add_model_to_world("Ramp", models, world, None);
+fn add_environment(
+    models: &std::collections::HashMap<String, World>,
+    world: &mut World,
+    physics_context: &mut PhysicsContext,
+) {
+    add_model_to_world("Environment", models, world, physics_context, None);
+    add_model_to_world("Ramp", models, world, physics_context, None);
 }
 
 pub fn add_songs(audio_context: &mut AudioContext, game_context: &mut GameContext) {
@@ -241,7 +253,7 @@ pub fn pre_spawn_cube(
         Color::Blue => "Blue Cube",
     };
 
-    let cube = add_model_to_world(model_name, models, world, None).unwrap();
+    let cube = add_model_to_world(model_name, models, world, physics_context, None).unwrap();
 
     let rigid_body = RigidBodyBuilder::new(RigidBodyType::Dynamic)
         .lock_rotations()

--- a/examples/crab-saber/src/systems/sabers.rs
+++ b/examples/crab-saber/src/systems/sabers.rs
@@ -69,7 +69,7 @@ pub fn add_saber(
         Color::Blue => "Blue Saber",
         Color::Red => "Red Saber",
     };
-    let saber = add_model_to_world(model_name, models, world, None).unwrap();
+    let saber = add_model_to_world(model_name, models, world, physics_context, None).unwrap();
     add_saber_physics(world, physics_context, saber);
     world.insert(saber, (Saber {}, color)).unwrap();
     saber

--- a/examples/simple-scene/src/lib.rs
+++ b/examples/simple-scene/src/lib.rs
@@ -57,8 +57,12 @@ fn init(engine: &mut Engine) -> Result<World, hotham::HothamError> {
     #[cfg(not(target_os = "android"))]
     glb_buffers.push(include_bytes!("../../../test_assets/damaged_helmet.glb"));
 
-    let models =
-        asset_importer::load_models_from_glb(&glb_buffers, vulkan_context, render_context)?;
+    let models = asset_importer::load_models_from_glb(
+        &glb_buffers,
+        vulkan_context,
+        render_context,
+        physics_context,
+    )?;
     add_helmet(&models, &mut world, physics_context);
     add_hand(&models, Handedness::Left, &mut world, physics_context);
     add_hand(&models, Handedness::Right, &mut world, physics_context);
@@ -71,7 +75,7 @@ fn add_helmet(
     world: &mut World,
     physics_context: &mut PhysicsContext,
 ) {
-    let helmet = add_model_to_world("Damaged Helmet", models, world, None)
+    let helmet = add_model_to_world("Damaged Helmet", models, world, physics_context, None)
         .expect("Could not find Damaged Helmet");
     let mut local_transform = world.get_mut::<LocalTransform>(helmet).unwrap();
     local_transform.translation.z = -1.;

--- a/hotham/src/asset_importer/mod.rs
+++ b/hotham/src/asset_importer/mod.rs
@@ -362,7 +362,7 @@ fn find_wall_collider_for_node<'a>(
 
     // Iterate through each node to try and find the matching node, then fetch its mesh.
     import_context.document.nodes().find_map(|n| {
-        if n.name()? != &wall_pattern {
+        if n.name()? == wall_pattern {
             return None;
         }
 

--- a/hotham/src/asset_importer/mod.rs
+++ b/hotham/src/asset_importer/mod.rs
@@ -362,7 +362,7 @@ fn find_wall_collider_for_node<'a>(
 
     // Iterate through each node to try and find the matching node, then fetch its mesh.
     import_context.document.nodes().find_map(|n| {
-        if n.name()? == wall_pattern {
+        if n.name()? != wall_pattern {
             return None;
         }
 

--- a/hotham/src/asset_importer/mod.rs
+++ b/hotham/src/asset_importer/mod.rs
@@ -3,19 +3,25 @@ pub mod scene;
 
 use crate::{
     components::{
-        animation_controller::AnimationController, GlobalTransform, Info, LocalTransform, Mesh,
-        Parent, Root, Skin, Visible,
+        animation_controller::AnimationController, Collider, GlobalTransform, Info, LocalTransform,
+        Mesh, Parent, Root, Skin, Visible,
     },
     rendering::{light::Light, material::Material},
-    resources::{RenderContext, VulkanContext},
+    resources::{physics_context::PhysicsContext, RenderContext, VulkanContext},
 };
 use anyhow::Result;
 
 use gltf::Document;
 use hecs::{Entity, World};
-use std::{borrow::Cow, collections::HashMap};
+use itertools::Itertools;
+use nalgebra::Isometry3;
+use std::{borrow::Cow, collections::HashMap, convert::TryInto};
 
 use self::scene::Scene;
+
+static COLLIDER_TAG: &str = ".HOTHAM_COLLIDER";
+static WALL_COLLIDER_TAG: &str = ".HOTHAM_COLLIDER_WALL";
+static SENSOR_COLLIDER_TAG: &str = ".HOTHAM_COLLIDER_SENSOR";
 
 /// Convenience type for models
 pub type Models = HashMap<String, World>;
@@ -24,6 +30,7 @@ pub type Models = HashMap<String, World>;
 pub(crate) struct ImportContext<'a> {
     pub vulkan_context: &'a VulkanContext,
     pub render_context: &'a mut RenderContext,
+    pub physics_context: &'a mut PhysicsContext,
     pub models: Models,
     pub node_entity_map: HashMap<usize, Entity>,
     pub mesh_map: HashMap<usize, Mesh>,
@@ -36,6 +43,7 @@ impl<'a> ImportContext<'a> {
     fn new(
         vulkan_context: &'a VulkanContext,
         render_context: &'a mut RenderContext,
+        physics_context: &'a mut PhysicsContext,
         glb_buffer: &'a [u8],
     ) -> Self {
         let glb = gltf::Glb::from_slice(glb_buffer).unwrap();
@@ -47,6 +55,7 @@ impl<'a> ImportContext<'a> {
         Self {
             vulkan_context,
             render_context,
+            physics_context,
             models: Default::default(),
             node_entity_map: Default::default(),
             mesh_map: Default::default(),
@@ -62,11 +71,13 @@ pub fn load_scene_from_glb(
     glb_buffer: &[u8],
     vulkan_context: &VulkanContext,
     render_context: &mut RenderContext,
+    physics_context: &mut PhysicsContext,
 ) -> Result<Scene> {
     // Global models map, shared between imports.
     let mut models = HashMap::new();
 
-    let mut import_context = ImportContext::new(vulkan_context, render_context, glb_buffer);
+    let mut import_context =
+        ImportContext::new(vulkan_context, render_context, physics_context, glb_buffer);
     load_models_from_gltf_data(&mut import_context).unwrap();
 
     // Take all the models we imported and add them to the global map
@@ -101,12 +112,14 @@ pub fn load_models_from_glb(
     glb_buffers: &[&[u8]],
     vulkan_context: &VulkanContext,
     render_context: &mut RenderContext,
+    physics_context: &mut PhysicsContext,
 ) -> Result<Models> {
     // Global models map, shared between imports.
     let mut models = HashMap::new();
 
     for glb_buffer in glb_buffers {
-        let mut import_context = ImportContext::new(vulkan_context, render_context, glb_buffer);
+        let mut import_context =
+            ImportContext::new(vulkan_context, render_context, physics_context, glb_buffer);
         load_models_from_gltf_data(&mut import_context).unwrap();
 
         // Take all the models we imported and add them to the global map
@@ -123,7 +136,15 @@ fn load_models_from_gltf_data(import_context: &mut ImportContext) -> Result<()> 
     // A bit lazy, but whatever.
     let document = import_context.document.clone();
 
+    // Identify meshes that will be used for collider geometry.
+    let collider_mesh_ids = get_collider_mesh_ids(document.nodes());
+
     for mesh in document.meshes() {
+        // Don't load meshes that are going to be used as collider geometry
+        if collider_mesh_ids.contains(&mesh.index()) {
+            continue;
+        }
+
         Mesh::load(mesh, import_context);
     }
 
@@ -134,7 +155,17 @@ fn load_models_from_gltf_data(import_context: &mut ImportContext) -> Result<()> 
     // We need *some* entity to stash the AnimationController onto.
     // For now, just use the first root entity.
     let mut animation_controller_entity = None;
-    for node in document.scenes().next().unwrap().nodes() {
+
+    // NOTE: We don't currently support multiple scenes, so we just take the first one.
+    let scene = document.scenes().next().unwrap();
+
+    // Iterate through each of the root nodes in the scene and load it in.
+    for node in scene.nodes() {
+        // Don't add wall collider geometry as nodes.
+        if node.name().unwrap_or_default().ends_with(WALL_COLLIDER_TAG) {
+            continue;
+        }
+
         let mut world = World::default();
 
         let root = load_node(&node, import_context, &mut world, true);
@@ -144,7 +175,7 @@ fn load_models_from_gltf_data(import_context: &mut ImportContext) -> Result<()> 
             animation_controller_entity = Some(root);
         }
 
-        add_parents(&node, &mut world, &mut import_context.node_entity_map);
+        build_node_hierarchy(&node, &mut world, &mut import_context.node_entity_map);
 
         import_context
             .models
@@ -176,6 +207,21 @@ fn load_models_from_gltf_data(import_context: &mut ImportContext) -> Result<()> 
     Ok(())
 }
 
+fn get_collider_mesh_ids(nodes: gltf::iter::Nodes) -> Vec<usize> {
+    let mut mesh_ids = Vec::new();
+    for node in nodes {
+        if !node.name().unwrap_or_default().contains(COLLIDER_TAG) {
+            continue;
+        }
+
+        if let Some(mesh) = node.mesh() {
+            mesh_ids.push(mesh.index())
+        }
+    }
+
+    mesh_ids
+}
+
 fn load_skins(node: gltf::Node, import_context: &mut ImportContext) {
     if let Some(skin) = node.skin() {
         // Load the skin
@@ -201,26 +247,32 @@ fn load_skins(node: gltf::Node, import_context: &mut ImportContext) {
 
 #[cfg_attr(feature = "cargo-clippy", allow(clippy::too_many_arguments))]
 fn load_node(
-    node_data: &gltf::Node,
+    node: &gltf::Node,
     import_context: &mut ImportContext,
     world: &mut World,
     is_root: bool,
 ) -> Entity {
-    let local_transform = LocalTransform::load(node_data.transform());
-    let global_transform = GlobalTransform(node_data.transform().matrix().into());
+    // First, get the transform of the node.
+    let local_transform = LocalTransform::load(node.transform());
+    let global_transform = GlobalTransform(node.transform().matrix().into());
+
+    // Next, collect some information about the node and store it in an [`Info`] component
     let info = Info {
-        name: node_data
+        name: node
             .name()
             .map(|s| s.to_string())
-            .unwrap_or(format!("Node {}", node_data.index())),
-        node_id: node_data.index(),
+            .unwrap_or(format!("Node {}", node.index())),
+        node_id: node.index(),
     };
+
+    // Now spawn an entity to represent this node and store it in our entity map.
     let this_entity = world.spawn((local_transform, global_transform, info));
     import_context
         .node_entity_map
-        .insert(node_data.index(), this_entity);
+        .insert(node.index(), this_entity);
 
-    if let Some(mesh) = node_data
+    // If the node had a mesh, add the mesh as a component and give it a `Visible` component
+    if let Some(mesh) = node
         .mesh()
         .and_then(|m| import_context.mesh_map.get(&m.index()))
     {
@@ -229,18 +281,132 @@ fn load_node(
             .unwrap();
     }
 
+    // If this node is at the root, mark it with a `Root` component.
     if is_root {
         world.insert_one(this_entity, Root {}).unwrap();
     }
 
-    for child in node_data.children() {
+    // If this node has corresponding collider geometry, add it in.
+    if let Some(collider) = get_collider_for_node(
+        node,
+        import_context,
+        this_entity,
+        local_transform.position(),
+    ) {
+        world.insert_one(this_entity, collider).unwrap();
+    }
+
+    // Now walk through each of this node's children and load them in.
+    for child in node.children() {
         load_node(&child, import_context, world, false);
     }
 
     this_entity
 }
 
-fn add_parents(
+/// Searches through the glTF document to find a mesh that can be used by Hotham to represent a collider, then creates one.
+///
+/// There are two kinds of colliders we're looking for:
+///
+/// - Walls, which are stored separate node with the same root name as some entity, eg. `cube` and `cube.HOTHAM_COLLIDER_WALL`
+/// - Sensors, which are their own separate nodes, eg. `phantom.HOTHAM_COLLIDER_SENSOR`
+fn get_collider_for_node(
+    node: &gltf::Node,
+    import_context: &mut ImportContext,
+    this_entity: Entity,
+    position: Isometry3<f32>,
+) -> Option<Collider> {
+    // First, get the name of the node, if it has one.
+    let node_name = node.name()?;
+
+    // Next, check to see if this is either a node that should be treated as a sensor
+    // OR a node that has another node representing a wall collider somewhere in the document.
+    let (collider_node_name, mesh) = if node_name.ends_with(SENSOR_COLLIDER_TAG) {
+        (node_name, node.mesh()?)
+    } else {
+        find_wall_collider_for_node(node_name, import_context)?
+    };
+
+    // Build a collider using the mesh.
+    let shape = get_shape_from_mesh(mesh, import_context);
+    let collider_builder = rapier3d::geometry::ColliderBuilder::new(shape)
+        .user_data(this_entity.to_bits().get() as _)
+        .position(position);
+
+    // If this is a wall collider, ensure it's not a sensor.
+    let collider = if collider_node_name.ends_with(WALL_COLLIDER_TAG) {
+        println!(
+            "[HOTHAM_ASSET_IMPORTER] Created wall collider for model {}",
+            collider_node_name
+        );
+        collider_builder.sensor(false).build()
+    } else {
+        println!(
+            "[HOTHAM_ASSET_IMPORTER] Created sensor collider for model {}",
+            collider_node_name
+        );
+        collider_builder.sensor(true).build()
+    };
+
+    let handle = import_context.physics_context.colliders.insert(collider);
+
+    Some(Collider::new(handle))
+}
+
+fn find_wall_collider_for_node<'a>(
+    name: &'a str,
+    import_context: &'a ImportContext,
+) -> Option<(&'a str, gltf::Mesh<'a>)> {
+    // Create a pattern to search for the collider's name, suffixed with the wall collider tag.
+    let wall_pattern = format!("{}{}", name, WALL_COLLIDER_TAG);
+
+    // Iterate through each node to try and find the matching node, then fetch its mesh.
+    import_context.document.nodes().find_map(|n| {
+        if n.name()? != &wall_pattern {
+            return None;
+        }
+
+        n.mesh().map(|mesh| (n.name().unwrap(), mesh))
+    })
+}
+
+/// Use Rapier's convex_decomposition to create a shape from the mesh geometry.
+fn get_shape_from_mesh(
+    mesh: gltf::Mesh,
+    import_context: &ImportContext,
+) -> rapier3d::geometry::SharedShape {
+    let mut positions = Vec::new();
+    let mut indices: Vec<[u32; 3]> = Default::default();
+
+    for primitive in mesh.primitives() {
+        let reader = primitive.reader(|_| Some(&import_context.buffer));
+        if let Some(iter) = reader.read_positions() {
+            for p in iter {
+                positions.push(p.into());
+            }
+        } else {
+            panic!("[HOTHAM_ASSET_IMPORTER] - Unable to create collider, mesh has no positions!");
+        }
+
+        if let Some(iter) = reader.read_indices() {
+            for chunk in &iter.into_u32().chunks(3) {
+                indices.push(chunk.collect::<Vec<_>>().try_into().expect(
+                    "[HOTHAM_ASSET_IMPORTER] - Unable to create collider, invalid geometry!",
+                ));
+            }
+        } else {
+            panic!("[HOTHAM_ASSET_IMPORTER] - Unable to create collider, mesh has no positions!");
+        }
+    }
+
+    rapier3d::geometry::SharedShape::convex_decomposition(&positions, &indices)
+}
+
+/// Recursively walk through this node's hierarchy and connect child nodes to their parents by adding a [`Parent`] component.
+///
+/// **NOTE**: We only support very minimal parent -> child inheritance. At present only visibilty and transforms
+///       are inherited.
+fn build_node_hierarchy(
     node_data: &gltf::Node,
     world: &mut World,
     node_entity_map: &mut HashMap<usize, Entity>,
@@ -251,7 +417,7 @@ fn add_parents(
         let child_id = child_node.index();
         let child_entity = node_entity_map.get(&child_id).unwrap();
         world.insert_one(*child_entity, parent).unwrap();
-        add_parents(&child_node, world, node_entity_map);
+        build_node_hierarchy(&child_node, world, node_entity_map);
     }
 }
 
@@ -260,6 +426,7 @@ pub fn add_model_to_world(
     name: &str,
     models: &Models,
     destination_world: &mut World,
+    physics_context: &mut PhysicsContext,
     parent: Option<Entity>,
 ) -> Option<Entity> {
     let source_world = models.get(name)?;
@@ -362,6 +529,21 @@ pub fn add_model_to_world(
                 .insert_one(*destination_entity, *visible)
                 .unwrap();
         }
+
+        // If the entity had a collider attached, clone it and update its user data to point to the new entity.
+        if let Ok(collider) = source_world.get_mut::<Collider>(*source_entity) {
+            let mut new_collider = physics_context
+                .colliders
+                .get(collider.handle)
+                .unwrap()
+                .clone();
+            new_collider.user_data = source_entity.to_bits().get() as _;
+            let new_collider = Collider::new(physics_context.colliders.insert(new_collider));
+
+            destination_world
+                .insert_one(*destination_entity, new_collider)
+                .unwrap();
+        }
     }
 
     // Find the root entity of the source world.
@@ -381,19 +563,29 @@ pub fn add_model_to_world(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::components::{LocalTransform, Root};
+    use crate::{
+        components::{LocalTransform, Root},
+        resources::physics_context,
+    };
     use approx::assert_relative_eq;
     use nalgebra::{vector, Quaternion, UnitQuaternion};
 
     #[test]
     pub fn test_load_models() {
         let (mut render_context, vulkan_context) = RenderContext::testing();
+        let mut physics_context = Default::default();
 
         let data: Vec<&[u8]> = vec![
             include_bytes!("../../../test_assets/damaged_helmet.glb"),
             include_bytes!("../../../test_assets/asteroid.glb"),
         ];
-        let models = load_models_from_glb(&data, &vulkan_context, &mut render_context).unwrap();
+        let models = load_models_from_glb(
+            &data,
+            &vulkan_context,
+            &mut render_context,
+            &mut physics_context,
+        )
+        .unwrap();
         let test_data = vec![
             (
                 "Damaged Helmet",
@@ -428,7 +620,7 @@ mod tests {
                 .expect(&format!("Unable to find model with name {}", name));
 
             let mut world = World::default();
-            let model = add_model_to_world(*name, &models, &mut world, None);
+            let model = add_model_to_world(*name, &models, &mut world, &mut physics_context, None);
             assert!(model.is_some(), "Model {} could not be added", name);
 
             let model = model.unwrap();
@@ -486,19 +678,34 @@ mod tests {
     #[test]
     fn test_load_model_with_no_material() {
         let (mut render_context, vulkan_context) = RenderContext::testing();
+        let mut physics_context = PhysicsContext::default();
         let data: Vec<&[u8]> = vec![include_bytes!("../../../test_assets/box_no_material.glb")];
-        let _models = load_models_from_glb(&data, &vulkan_context, &mut render_context).unwrap();
+        let _models = load_models_from_glb(
+            &data,
+            &vulkan_context,
+            &mut render_context,
+            &mut physics_context,
+        )
+        .unwrap();
     }
 
     #[test]
     pub fn test_hand() {
         let (mut render_context, vulkan_context) = RenderContext::testing();
+        let mut physics_context = PhysicsContext::default();
 
         let data: Vec<&[u8]> = vec![include_bytes!("../../../test_assets/left_hand.glb")];
-        let models = load_models_from_glb(&data, &vulkan_context, &mut render_context).unwrap();
+        let models = load_models_from_glb(
+            &data,
+            &vulkan_context,
+            &mut render_context,
+            &mut physics_context,
+        )
+        .unwrap();
 
         let mut world = World::default();
-        let _hand = add_model_to_world("Left Hand", &models, &mut world, None);
+        let _hand =
+            add_model_to_world("Left Hand", &models, &mut world, &mut physics_context, None);
 
         // Make sure there is only one root
         let mut roots = world
@@ -548,5 +755,38 @@ mod tests {
                 assert!(world.contains(target.target));
             }
         }
+    }
+
+    #[test]
+    fn test_load_model_with_colliders() {
+        let (mut render_context, vulkan_context) = RenderContext::testing();
+        let mut physics_context = physics_context::PhysicsContext::default();
+        let mut world = World::default();
+
+        let data: Vec<&[u8]> = vec![include_bytes!(
+            "../../../test_assets/box_with_colliders.glb"
+        )];
+        let models = load_models_from_glb(
+            &data,
+            &vulkan_context,
+            &mut render_context,
+            &mut physics_context,
+        )
+        .unwrap();
+        for name in models.keys() {
+            add_model_to_world(name, &models, &mut world, &mut physics_context, None);
+        }
+
+        // There are two wolv-- colliders.
+        let query = world.query_mut::<&Collider>();
+        assert_eq!(query.into_iter().len(), 2);
+
+        // Make sure we got the wall collider
+        let query = world.query_mut::<(&Collider, &Mesh)>();
+        assert_eq!(query.into_iter().len(), 1);
+
+        // ..and make sure we got the sensor collider
+        let query = world.query_mut::<hecs::Without<Mesh, &Collider>>();
+        assert_eq!(query.into_iter().len(), 1);
     }
 }

--- a/hotham/src/systems/animation.rs
+++ b/hotham/src/systems/animation.rs
@@ -26,20 +26,29 @@ pub fn animation_system(query: &mut PreparedQuery<&AnimationController>, world: 
 mod tests {
     use crate::{
         asset_importer::{add_model_to_world, load_models_from_glb},
-        resources::RenderContext,
+        resources::{PhysicsContext, RenderContext},
     };
 
     use super::*;
     #[test]
     pub fn animation_test() {
         let (mut render_context, vulkan_context) = RenderContext::testing();
+        let mut physics_context = PhysicsContext::default();
 
         let data: Vec<&[u8]> = vec![include_bytes!("../../../test_assets/left_hand.glb")];
-        let models = load_models_from_glb(&data, &vulkan_context, &mut render_context).unwrap();
+        let models = load_models_from_glb(
+            &data,
+            &vulkan_context,
+            &mut render_context,
+            &mut physics_context,
+        )
+        .unwrap();
         let mut world = World::new();
 
         // Add the left hand
-        let left_hand = add_model_to_world("Left Hand", &models, &mut world, None).unwrap();
+        let left_hand =
+            add_model_to_world("Left Hand", &models, &mut world, &mut physics_context, None)
+                .unwrap();
         {
             let mut left_hand_controller = world.get_mut::<AnimationController>(left_hand).unwrap();
             left_hand_controller.blend_from = 0;

--- a/hotham/src/systems/draw_gui.rs
+++ b/hotham/src/systems/draw_gui.rs
@@ -331,9 +331,13 @@ mod tests {
         let gltf_data: Vec<&[u8]> = vec![include_bytes!(
             "../../../test_assets/ferris-the-crab/source/ferris.glb"
         )];
-        let mut models =
-            asset_importer::load_models_from_glb(&gltf_data, &vulkan_context, &mut render_context)
-                .unwrap();
+        let mut models = asset_importer::load_models_from_glb(
+            &gltf_data,
+            &vulkan_context,
+            &mut render_context,
+            &mut physics_context,
+        )
+        .unwrap();
         let (_, mut world) = models.drain().next().unwrap();
 
         let panel = add_ui_panel_to_world(

--- a/hotham/src/systems/hands.rs
+++ b/hotham/src/systems/hands.rs
@@ -74,7 +74,7 @@ pub fn add_hand(
         Handedness::Left => "Left Hand",
         Handedness::Right => "Right Hand",
     };
-    let hand = add_model_to_world(model_name, models, world, None).unwrap();
+    let hand = add_model_to_world(model_name, models, world, physics_context, None).unwrap();
     {
         // Add a hand component
         world

--- a/hotham/src/systems/rendering.rs
+++ b/hotham/src/systems/rendering.rs
@@ -245,9 +245,8 @@ mod tests {
     use ash::vk;
     use ash::vk::Handle;
     use image::{codecs::jpeg::JpegEncoder, DynamicImage, RgbaImage};
-    use nalgebra::{Translation3, UnitQuaternion, Vector3};
+    use nalgebra::{Isometry3, Translation3, UnitQuaternion, Vector3};
     use openxr::{Fovf, Quaternionf, Vector3f};
-    use rapier3d::prelude::Isometry;
     use update_local_transform_with_rigid_body::update_local_transform_with_rigid_body_system;
 
     use crate::{
@@ -268,6 +267,7 @@ mod tests {
     #[test]
     pub fn test_rendering_pbr() {
         let vulkan_context = VulkanContext::testing().unwrap();
+        let mut physics_context = PhysicsContext::default();
         let resolution = vk::Extent2D {
             height: 800,
             width: 800,
@@ -293,16 +293,19 @@ mod tests {
 
         let mut render_context =
             RenderContext::new_from_swapchain_info(&vulkan_context, &swapchain).unwrap();
-        let mut physics_context = PhysicsContext::default();
 
         let gltf_data: Vec<&[u8]> = vec![include_bytes!("../../../test_assets/damaged_helmet.glb")];
-        let mut models =
-            asset_importer::load_models_from_glb(&gltf_data, &vulkan_context, &mut render_context)
-                .unwrap();
+        let mut models = asset_importer::load_models_from_glb(
+            &gltf_data,
+            &vulkan_context,
+            &mut render_context,
+            &mut physics_context,
+        )
+        .unwrap();
         let (_, mut world) = models.drain().next().unwrap();
 
         // Add stage transform
-        let global_from_stage = Isometry::from_parts(
+        let global_from_stage = Isometry3::from_parts(
             Translation3::new(0.1, 0.2, 0.3),
             UnitQuaternion::from_scaled_axis(Vector3::y() * (std::f32::consts::TAU * 0.1)),
         );

--- a/hotham/src/systems/skinning.rs
+++ b/hotham/src/systems/skinning.rs
@@ -39,6 +39,7 @@ mod tests {
 
     use crate::{
         components::{Info, Skin},
+        resources::PhysicsContext,
         util::get_world_with_hands,
     };
 
@@ -49,7 +50,9 @@ mod tests {
     #[test]
     pub fn test_hand_skinning() {
         let (mut render_context, vulkan_context) = RenderContext::testing();
-        let mut world = get_world_with_hands(&vulkan_context, &mut render_context);
+        let mut physics_context = PhysicsContext::default();
+        let mut world =
+            get_world_with_hands(&vulkan_context, &mut render_context, &mut physics_context);
         skinning_system(&mut Default::default(), &mut world, &mut render_context);
 
         assert!(verify_matrices(&world, &render_context));

--- a/hotham/src/util.rs
+++ b/hotham/src/util.rs
@@ -36,7 +36,7 @@ use hecs::World;
 #[cfg(test)]
 use crate::{
     asset_importer::{add_model_to_world, load_models_from_glb},
-    resources::{RenderContext, VulkanContext},
+    resources::{PhysicsContext, RenderContext, VulkanContext},
 };
 
 /// Convenience function to get a world with hands
@@ -44,6 +44,7 @@ use crate::{
 pub fn get_world_with_hands(
     vulkan_context: &VulkanContext,
     render_context: &mut RenderContext,
+    physics_context: &mut PhysicsContext,
 ) -> World {
     use crate::components::{LocalTransform, Skin};
 
@@ -51,18 +52,21 @@ pub fn get_world_with_hands(
         include_bytes!("../../test_assets/left_hand.glb"),
         include_bytes!("../../test_assets/right_hand.glb"),
     ];
-    let models = load_models_from_glb(&data, vulkan_context, render_context).unwrap();
+    let models =
+        load_models_from_glb(&data, vulkan_context, render_context, physics_context).unwrap();
 
     let mut world = World::new();
 
     // Add two hands
-    let left_hand = add_model_to_world("Left Hand", &models, &mut world, None).unwrap();
+    let left_hand =
+        add_model_to_world("Left Hand", &models, &mut world, physics_context, None).unwrap();
     {
         let mut local_transform = world.get_mut::<LocalTransform>(left_hand).unwrap();
         local_transform.translation = [-0.2, 1.4, 0.0].into();
     }
 
-    let right_hand = add_model_to_world("Right Hand", &models, &mut world, None).unwrap();
+    let right_hand =
+        add_model_to_world("Right Hand", &models, &mut world, physics_context, None).unwrap();
     {
         let mut local_transform = world.get_mut::<LocalTransform>(right_hand).unwrap();
         local_transform.translation = [0.2, 1.4, 0.0].into();

--- a/test_assets/box_with_colliders.glb
+++ b/test_assets/box_with_colliders.glb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2cd373968e7cf532923f1be43851c7b01b41925d5ed96183a6b6e140168595de
+size 31240


### PR DESCRIPTION
## What is this related to?
Closes #351

## What changed?
- Added the ability to define colliders using mesh geometry, then add a corresponding `Collider` component to the entity
- Initial support is for two kinds of colliders - walls and sensors
- Sensors have no corresponding mesh and are configured as Rapier sensors. These are tagged with the `".HOTHAM_COLLIDER_SENSOR"` suffiix in the node's name.
- Walls are attached as a collider to an entity that has a mesh by adding the `".HOTHAM_COLLIDER_WALL"` suffix to the node's name, eg `"cube"` will receive a collider that's named `"cube.HOTHAM_COLLIDER_WALL"`

## What is the overall impact?
- You can now define colliders with (mostly) arbitrary geometry 🎉 

## Future work
- https://github.com/leetvr/hotham/issues/363