### PR TITLE
Fix incorrect f0 term in fragment shader

### DIFF
--- a/hotham/src/rendering/scene_data.rs
+++ b/hotham/src/rendering/scene_data.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use super::light::{Light, MAX_LIGHTS};
 
 /// The amount of Image Based Lighting (IBL) to show in the scene
-pub const DEFAULT_IBL_INTENSITY: f32 = 0.4;
+pub const DEFAULT_IBL_INTENSITY: f32 = 1.0;
 
 /// Data about the current scene. Sent to the vertex and fragment shaders
 #[derive(Deserialize, Serialize, Clone, Debug, Copy)]

--- a/hotham/src/shaders/brdf.glsl
+++ b/hotham/src/shaders/brdf.glsl
@@ -7,10 +7,12 @@
 
 // The following equation models the Fresnel reflectance term of the spec equation (aka F())
 // Implementation of fresnel from [4], Equation 15
-
 const float M_PI = 3.141592653589793;
 
-vec3 F_Schlick(vec3 f0, vec3 f90, float VdotH) {
+// Anything less than 2% is physically impossible and is instead considered to be shadowing. Compare to "Real-Time-Rendering" 4th edition on page 325.
+const vec3 f90 = vec3(1.0);
+
+vec3 F_Schlick(vec3 f0, float VdotH) {
     return f0 + (f90 - f0) * pow(clamp(1.0 - VdotH, 0.0, 1.0), 5.0);
 }
 
@@ -42,14 +44,14 @@ float D_GGX(float NdotH, float alphaRoughness) {
 }
 
 //https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#acknowledgments AppendixB
-vec3 BRDF_lambertian(vec3 f0, vec3 f90, vec3 diffuseColor, float VdotH) {
+vec3 BRDF_lambertian(vec3 f0, vec3 diffuseColor, float VdotH) {
     // see https://seblagarde.wordpress.com/2012/01/08/pi-or-not-to-pi-in-game-lighting-equation/
-    return (1.0 - F_Schlick(f0, f90, VdotH)) * (diffuseColor / M_PI);
+    return (1.0 - F_Schlick(f0, VdotH)) * (diffuseColor / M_PI);
 }
 
 //  https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#acknowledgments AppendixB
-vec3 BRDF_specularGGX(vec3 f0, vec3 f90, float alphaRoughness, float VdotH, float NdotL, float NdotV, float NdotH) {
-    vec3 F = F_Schlick(f0, f90, VdotH);
+vec3 BRDF_specularGGX(vec3 f0, float alphaRoughness, float VdotH, float NdotL, float NdotV, float NdotH) {
+    vec3 F = F_Schlick(f0, VdotH);
     float Vis = V_GGX(NdotL, NdotV, alphaRoughness);
     float D = D_GGX(NdotH, alphaRoughness);
 

--- a/hotham/src/shaders/pbr.glsl
+++ b/hotham/src/shaders/pbr.glsl
@@ -1,4 +1,3 @@
-const float epsilon = 1e-6;
 #define DEFAULT_EXPOSURE 1.0
 #define DEFAULT_IBL_SCALE 0.4
 #define DEFAULT_CUBE_MIPMAP_LEVELS 10
@@ -21,20 +20,11 @@ struct Material {
     float alphaMaskCutoff;
 };
 
-// Encapsulate BRDF information about this material
-struct MaterialInfo {
-    vec3 f0;                      // full reflectance color (normal incidence angle)
-    vec3 diffuseColor;            // color contribution from diffuse lighting
-    vec3 specularColor;           // color contribution from specular lighting
-    float alphaRoughness;         // roughness mapped to a more linear change in the roughness (proposed by [2])
-    float perceptualRoughness;    // roughness value, as authored by the model creator (input to shader)
-};
-
 const float PBR_WORKFLOW_METALLIC_ROUGHNESS = 0.0;
 const float PBR_WORKFLOW_UNLIT = 1.0;
 
-// Anything less than 2% is physically impossible and is instead considered to be shadowing. Compare to "Real-Time-Rendering" 4th edition on page 325.
-const vec3 f90 = vec3(1.0);
+// The default index of refraction of 1.5 yields a dielectric normal incidence reflectance (eg. f0) of 0.04
+const vec3 DEFAULT_F0 = vec3(0.04);
 
 // Fast approximation of ACES tonemap
 // https://knarkowicz.wordpress.com/2016/01/06/aces-filmic-tone-mapping-curve/
@@ -82,36 +72,35 @@ vec3 getNormal(uint normalTextureID) {
 }
 
 // Calculation of the lighting contribution from an optional Image Based Light source.
-vec3 getIBLContribution(MaterialInfo materialInfo, vec3 n, vec3 reflection, float NdotV) {
-    vec3 F0 = materialInfo.f0;
-    float lod = materialInfo.perceptualRoughness * float(DEFAULT_CUBE_MIPMAP_LEVELS - 1);
+vec3 getIBLContribution(vec3 F0, float perceptualRoughness, vec3 diffuseColor, vec3 reflection, float NdotV) {
+    float lod = perceptualRoughness * float(DEFAULT_CUBE_MIPMAP_LEVELS - 1);
 
-    vec2 brdfSamplePoint = clamp(vec2(NdotV, materialInfo.perceptualRoughness), vec2(0.0, 0.0), vec2(1.0, 1.0));
+    vec2 brdfSamplePoint = clamp(vec2(NdotV, perceptualRoughness), vec2(0.0, 0.0), vec2(1.0, 1.0));
     vec2 f_ab = texture(textures[BRDF_LUT_TEXTURE_ID], brdfSamplePoint).rg;
 
     vec3 specularLight = textureLod(cubeTextures[ENVIRONMENT_MAP_TEXTURE_ID], reflection, lod).rgb;
-    vec3 diffuseLight = textureLod(cubeTextures[SAMPLER_IRRADIANCE_TEXTURE_ID], reflection, lod).rgb;
 
     // see https://bruop.github.io/ibl/#single_scattering_results at Single Scattering Results
     // Roughness dependent fresnel, from Fdez-Aguera
-    vec3 Fr = max(vec3(1.0 - materialInfo.perceptualRoughness), F0) - F0;
+    vec3 Fr = max(vec3(1.0 - perceptualRoughness), F0) - F0;
     vec3 k_S = F0 + Fr * pow(1.0 - NdotV, 5.0);
     vec3 FssEss = k_S * f_ab.x + f_ab.y;
 
     vec3 specular = specularLight * FssEss;
 
     // Multiple scattering, from Fdez-Aguera
+    vec3 diffuseLight = textureLod(cubeTextures[SAMPLER_IRRADIANCE_TEXTURE_ID], reflection, lod).rgb;
     float Ems = (1.0 - (f_ab.x + f_ab.y));
     vec3 F_avg = F0 + (1.0 - F0) / 21.0;
     vec3 FmsEms = Ems * FssEss * F_avg / (1.0 - F_avg * Ems);
-    vec3 k_D = materialInfo.diffuseColor * (1.0 - FssEss + FmsEms); // we use +FmsEms as indicated by the formula in the blog post (might be a typo in the implementation)
+    vec3 k_D = diffuseColor * (1.0 - FssEss + FmsEms); // we use +FmsEms as indicated by the formula in the blog post (might be a typo in the implementation)
 
     vec3 diffuse = (FmsEms + k_D) * diffuseLight;
 
     return diffuse + specular;
 }
 
-vec3 getLightContribution(MaterialInfo materialInfo, vec3 n, vec3 v, float NdotV, Light light) {
+vec3 getLightContribution(vec3 F0, float alphaRoughness, vec3 diffuseColor, vec3 n, vec3 v, float NdotV, Light light) {
     // Get a vector between this point and the light.
     vec3 pointToLight;
     if (light.type != LightType_Directional) {
@@ -125,7 +114,6 @@ vec3 getLightContribution(MaterialInfo materialInfo, vec3 n, vec3 v, float NdotV
 
     float NdotL = clamp(dot(n, l), 0.0, 1.0);
     float NdotH = clamp(dot(n, h), 0.0, 1.0);
-    float LdotH = clamp(dot(l, h), 0.0, 1.0);
     float VdotH = clamp(dot(v, h), 0.0, 1.0);
 
     vec3 color;
@@ -134,8 +122,8 @@ vec3 getLightContribution(MaterialInfo materialInfo, vec3 n, vec3 v, float NdotV
         vec3 intensity = getLightIntensity(light, pointToLight);
 
         // Obtain final intensity as reflectance (BRDF) scaled by the energy of the light (cosine law)
-        vec3 diffuseContrib = intensity * NdotL * BRDF_lambertian(materialInfo.f0, f90, materialInfo.diffuseColor, VdotH);
-        vec3 specContrib = intensity * NdotL * BRDF_specularGGX(materialInfo.f0, f90, materialInfo.alphaRoughness, VdotH, NdotL, NdotV, NdotH);
+        vec3 diffuseContrib = intensity * NdotL * BRDF_lambertian(F0, diffuseColor, VdotH);
+        vec3 specContrib = intensity * NdotL * BRDF_specularGGX(F0, alphaRoughness, VdotH, NdotL, NdotV, NdotH);
 
         // Finally, combine the diffuse and specular contributions
         color = diffuseContrib + specContrib;
@@ -165,16 +153,15 @@ vec3 getPBRMetallicRoughnessColor(Material material, vec4 baseColor) {
         metalness = clamp(mrSample.b * metalness, 0.0, 1.0);
     }
 
+    // Get this material's f0
+    vec3 f0 = mix(vec3(DEFAULT_F0), baseColor.rgb, metalness);
+
     // Get the diffuse color
-    vec3 f0 = mix(vec3(0.4), baseColor.rgb, metalness);
     vec3 diffuseColor = mix(baseColor.rgb, vec3(0.), metalness);
 
     // Roughness is authored as perceptual roughness; as is convention,
     // convert to material roughness by squaring the perceptual roughness
     float alphaRoughness = perceptualRoughness * perceptualRoughness;
-
-    // Get specular color
-    vec3 specularColor = mix(f0, baseColor.rgb, metalness);
 
     // Get the view vector - from surface point to camera
     vec3 v = normalize(sceneData.cameraPosition[gl_ViewIndex].xyz - inGosPos);
@@ -182,18 +169,14 @@ vec3 getPBRMetallicRoughnessColor(Material material, vec4 baseColor) {
     // Get the normal
     vec3 n = getNormal(material.normalTextureID);
 
-    // Get NdotV
+    // Get NdotV and reflection
     float NdotV = clamp(abs(dot(n, v)), 0., 1.0);
-
-    vec3 reflection = -normalize(reflect(v, n));
-
-    // Collect all the material info.
-    MaterialInfo materialInfo = MaterialInfo(f0, diffuseColor, specularColor, alphaRoughness, perceptualRoughness);
+    vec3 reflection = normalize(reflect(-v, n));
 
     // Calculate lighting contribution from image based lighting source (IBL), scaled by a scene data parameter.
     vec3 color;
     if (sceneData.params.x > 0.) {
-        color = getIBLContribution(materialInfo, n, reflection, NdotV) * sceneData.params.x;
+        color = getIBLContribution(f0, perceptualRoughness, diffuseColor, reflection, NdotV) * sceneData.params.x;
     } else {
         color = vec3(0.);
     }
@@ -209,16 +192,16 @@ vec3 getPBRMetallicRoughnessColor(Material material, vec4 baseColor) {
     // Qualcomm's documentation suggests that loops are undesirable, so we do branches instead.
     // Since these values are uniform, they shouldn't have too high of a penalty.
     if (sceneData.lights[0].type != NOT_PRESENT) {
-        color += getLightContribution(materialInfo, n, v, NdotV, sceneData.lights[0]);
+        color += getLightContribution(f0, alphaRoughness, diffuseColor, n, v, NdotV, sceneData.lights[0]);
     }
     if (sceneData.lights[1].type != NOT_PRESENT) {
-        color += getLightContribution(materialInfo, n, v, NdotV, sceneData.lights[1]);
+        color += getLightContribution(f0, alphaRoughness, diffuseColor, n, v, NdotV, sceneData.lights[1]);
     }
     if (sceneData.lights[2].type != NOT_PRESENT) {
-        color += getLightContribution(materialInfo, n, v, NdotV, sceneData.lights[2]);
+        color += getLightContribution(f0, alphaRoughness, diffuseColor, n, v, NdotV, sceneData.lights[2]);
     }
     if (sceneData.lights[3].type != NOT_PRESENT) {
-        color += getLightContribution(materialInfo, n, v, NdotV, sceneData.lights[3]);
+        color += getLightContribution(f0, alphaRoughness, diffuseColor, n, v, NdotV, sceneData.lights[3]);
     }
 
     // Add emission, if present

--- a/hotham/src/systems/debug.rs
+++ b/hotham/src/systems/debug.rs
@@ -27,7 +27,7 @@ pub fn debug_system(engine: &mut Engine) {
 
     if input_context.right.a_button_just_pressed() {
         let params = &mut render_context.scene_data.params;
-        params.x = ((params.x - 0.1) % 5.) as f32;
+        params.x = ((params.x + 5. - 0.1) % 5.) as f32;
         println!("[HOTHAM_DEBUG] params.x is now {}", params.x);
     }
 }

--- a/hotham/src/systems/debug.rs
+++ b/hotham/src/systems/debug.rs
@@ -24,4 +24,10 @@ pub fn debug_system(engine: &mut Engine) {
         params.x = ((params.x + 0.1) % 5.) as f32;
         println!("[HOTHAM_DEBUG] params.x is now {}", params.x);
     }
+
+    if input_context.right.a_button_just_pressed() {
+        let params = &mut render_context.scene_data.params;
+        params.x = ((params.x - 0.1) % 5.) as f32;
+        println!("[HOTHAM_DEBUG] params.x is now {}", params.x);
+    }
 }


### PR DESCRIPTION
## What is this related to?
Fixes #393

## What changed?
Fixed a bug in the fragment shader, extracted magic number to avoid future issues.

## What is the overall impact?
PBR shader now looks much more correct:

### Before:
![image](https://user-images.githubusercontent.com/2022375/197934093-40cb73fb-04b1-43fc-a9dc-b0f5236adeb5.png)

### After:
![image](https://user-images.githubusercontent.com/2022375/197934109-c8357ed4-88c3-438e-a258-0cc87ba89e8b.png)
