### PR TITLE
Simplify quadrics in custom rendering example

### DIFF
--- a/examples/custom-rendering/scripts/run_on_device.sh
+++ b/examples/custom-rendering/scripts/run_on_device.sh
@@ -8,4 +8,10 @@ cd $scriptdir/..
 
 cargo apk run --release
 
+# Wait for the app to start
+for i in 1 2 3 4 5; do
+    adb shell pidof rust.crab_saber && break
+    sleep 1
+done
+
 adb logcat --pid="$(adb shell pidof rust.custom_rendering_example)"

--- a/examples/custom-rendering/src/shaders/quadric.frag
+++ b/examples/custom-rendering/src/shaders/quadric.frag
@@ -83,8 +83,7 @@ void main() {
 
     // Compute depth
     vec4 v_clip_coord = sceneData.viewProjection[gl_ViewIndex] * hitPoint;
-    float f_ndc_depth = v_clip_coord.z / v_clip_coord.w;
-    gl_FragDepth = f_ndc_depth;
+    gl_FragDepth = v_clip_coord.z / v_clip_coord.w;
 
     // Compute normal from gradient of surface quadric
     vec3 normal = normalize((d.surfaceQ * hitPoint).xyz);

--- a/examples/custom-rendering/src/shaders/quadric.frag
+++ b/examples/custom-rendering/src/shaders/quadric.frag
@@ -27,18 +27,18 @@ layout (std430, set = 0, binding = 1) readonly buffer MaterialBuffer {
 layout (location = 0) out vec4 outColor;
 layout (depth_less) out float gl_FragDepth;
 
+// These values are from https://registry.khronos.org/vulkan/specs/1.2-extensions/html/chap27.html#primrast-samplelocations
+const vec2 offsetSample0 = vec2(0.375 - 0.5, 0.125 - 0.5);
+const vec2 offsetSample1 = vec2(0.875 - 0.5, 0.375 - 0.5);
+const vec2 offsetSample2 = vec2(0.125 - 0.5, 0.625 - 0.5);
+const vec2 offsetSample3 = vec2(0.625 - 0.5, 0.875 - 0.5);
+
 void main() {
     // Start by setting the output color to a familiar "error" magenta.
     outColor = ERROR_MAGENTA;
 
     // Retrieve draw data
     QuadricData d = quadricDataBuffer.data[inInstanceIndex];
-
-    // These values are from https://registry.khronos.org/vulkan/specs/1.2-extensions/html/chap27.html#primrast-samplelocations
-    vec2 offsetSample0 = vec2(0.375 - 0.5, 0.125 - 0.5);
-    vec2 offsetSample1 = vec2(0.875 - 0.5, 0.375 - 0.5);
-    vec2 offsetSample2 = vec2(0.125 - 0.5, 0.625 - 0.5);
-    vec2 offsetSample3 = vec2(0.625 - 0.5, 0.875 - 0.5);
 
     // Find ray-quadric intersection, if any
     float a = dot(inRayDir, inSurfaceQTimesRayDir);

--- a/examples/custom-rendering/src/shaders/quadric.frag
+++ b/examples/custom-rendering/src/shaders/quadric.frag
@@ -45,23 +45,21 @@ void main() {
     vec4 surfaceQTimesRayDir = d.surfaceQ * rayDir;
 
     float a = dot(rayDir, surfaceQTimesRayDir);
-    float b = dot(rayOrigin, surfaceQTimesRayDir) + dot(rayDir, surfaceQTimesRayOrigin);
+    float b = dot(rayOrigin, surfaceQTimesRayDir);
     float c = dot(rayOrigin, surfaceQTimesRayOrigin);
-    // Discriminant from quadratic formula
+    // Discriminant from quadratic formula is
     // b^2 - 4ac
-    float discriminant = b * b - 4.0 * a * c;
+    // but we are able to simplify it by substituting b with b/2.
+    float discriminant = b * b - a * c;
     vec2 gradientOfDiscriminant = vec2(dFdx(discriminant), dFdy(discriminant));
     gl_SampleMask[0] = int(
         step(0.0, discriminant + dot(offsetSample0, gradientOfDiscriminant)) +
         step(0.0, discriminant + dot(offsetSample1, gradientOfDiscriminant)) * 2 +
         step(0.0, discriminant + dot(offsetSample2, gradientOfDiscriminant)) * 4 +
         step(0.0, discriminant + dot(offsetSample3, gradientOfDiscriminant)) * 8);
-    if (discriminant < 0.0) {
-        discriminant = 0.0;
-    }
 
     // Pick the solution that is facing us
-    float t = (b + sqrt(discriminant)) * -0.5 / a;
+    float t = -(b + sqrt(max(0.0, discriminant))) / a;
 
     if (t < -0.0001) {
         t = 0.0;

--- a/examples/custom-rendering/src/shaders/quadric.frag
+++ b/examples/custom-rendering/src/shaders/quadric.frag
@@ -48,11 +48,11 @@ void main() {
     // b^2 - 4ac
     float discriminant = b * b - 4.0 * a * c;
     vec2 gradientOfDiscriminant = vec2(dFdx(discriminant), dFdy(discriminant));
-    gl_SampleMask[0] =
-        int(step(0.0, discriminant + dot(offsetSample0, gradientOfDiscriminant))) * 1 +
-        int(step(0.0, discriminant + dot(offsetSample1, gradientOfDiscriminant))) * 2 +
-        int(step(0.0, discriminant + dot(offsetSample2, gradientOfDiscriminant))) * 4 +
-        int(step(0.0, discriminant + dot(offsetSample3, gradientOfDiscriminant))) * 8;
+    gl_SampleMask[0] = int(
+        step(0.0, discriminant + dot(offsetSample0, gradientOfDiscriminant)) +
+        step(0.0, discriminant + dot(offsetSample1, gradientOfDiscriminant)) * 2 +
+        step(0.0, discriminant + dot(offsetSample2, gradientOfDiscriminant)) * 4 +
+        step(0.0, discriminant + dot(offsetSample3, gradientOfDiscriminant)) * 8);
     if (discriminant < 0.0) {
         discriminant = 0.0;
     }
@@ -68,11 +68,11 @@ void main() {
     vec4 hitPoint = inRayOrigin + inRayDir * t.x;
     float boundsValue = 0.0001 - dot(hitPoint, d.boundsQ * hitPoint);
     vec2 gradientOfBoundsValue = vec2(dFdx(boundsValue), dFdy(boundsValue));
-    gl_SampleMask[0] &=
-        int(step(0.0, boundsValue + dot(offsetSample0, gradientOfBoundsValue))) * 1 +
-        int(step(0.0, boundsValue + dot(offsetSample1, gradientOfBoundsValue))) * 2 +
-        int(step(0.0, boundsValue + dot(offsetSample2, gradientOfBoundsValue))) * 4 +
-        int(step(0.0, boundsValue + dot(offsetSample3, gradientOfBoundsValue))) * 8;
+    gl_SampleMask[0] &= int(
+        step(0.0, boundsValue + dot(offsetSample0, gradientOfBoundsValue)) +
+        step(0.0, boundsValue + dot(offsetSample1, gradientOfBoundsValue)) * 2 +
+        step(0.0, boundsValue + dot(offsetSample2, gradientOfBoundsValue)) * 4 +
+        step(0.0, boundsValue + dot(offsetSample3, gradientOfBoundsValue)) * 8);
 
     // Discarding is postponed until here to make sure the derivatives above are valid.
     if (gl_SampleMask[0] == 0) {

--- a/examples/custom-rendering/src/shaders/quadric.frag
+++ b/examples/custom-rendering/src/shaders/quadric.frag
@@ -68,6 +68,7 @@ void main() {
         gl_SampleMask[0] = 0;
     }
 
+    // hitPoint.w = 1 because rayOrigin.w = 1 and rayDir.w = 0.
     vec4 hitPoint = rayOrigin + rayDir * t;
     float boundsValue = 0.0001 - dot(hitPoint, d.boundsQ * hitPoint);
     vec2 gradientOfBoundsValue = vec2(dFdx(boundsValue), dFdy(boundsValue));
@@ -81,9 +82,6 @@ void main() {
     if (gl_SampleMask[0] == 0) {
         discard;
     }
-
-    // We divide with w here because hitPoint is used without w further down.
-    hitPoint /= hitPoint.w;
 
     // Compute depth
     vec4 v_clip_coord = sceneData.viewProjection[gl_ViewIndex] * hitPoint;

--- a/examples/custom-rendering/src/shaders/quadric.vert
+++ b/examples/custom-rendering/src/shaders/quadric.vert
@@ -4,11 +4,8 @@
 
 layout (location = 0) in vec3 inPos;
 
-layout (location = 0) out vec4 outRayOrigin;
-layout (location = 1) out vec4 outRayDir;
-layout (location = 2) out vec4 outSurfaceQTimesRayOrigin;
-layout (location = 3) out vec4 outSurfaceQTimesRayDir;
-layout (location = 4) out flat uint outInstanceIndex;
+layout (location = 0) out vec4 outGosPos;
+layout (location = 1) out flat uint outInstanceIndex;
 
 #include "quadric.glsl"
 
@@ -19,12 +16,6 @@ out gl_PerVertex {
 void main() {
     QuadricData d = quadricDataBuffer.data[gl_InstanceIndex];
     outInstanceIndex = gl_InstanceIndex;
-
-    outRayOrigin = d.gosFromLocal * vec4(inPos, 1.0);
-    outRayDir = vec4((outRayOrigin.xyz / outRayOrigin.w) - sceneData.cameraPosition[gl_ViewIndex].xyz, 0.0);
-
-    outSurfaceQTimesRayOrigin = d.surfaceQ * outRayOrigin;
-    outSurfaceQTimesRayDir = d.surfaceQ * outRayDir;
-
-    gl_Position = sceneData.viewProjection[gl_ViewIndex] * outRayOrigin;
+    outGosPos = d.gosFromLocal * vec4(inPos, 1.0);
+    gl_Position = sceneData.viewProjection[gl_ViewIndex] * outGosPos;
 }


### PR DESCRIPTION
The code gets easier to read and possibly faster to run by doing less in the vertex shader and consolidate the logic in the fragment shader. It was also possible to simplify the fragment shader. The amount of data passed from the vertex shader to the fragment shader is greatly reduced. This makes vertices cheaper which is a bit funny when the point of this rendering technique is to enable perfectly curved geometry with very few vertices.