### PR TITLE
Rasmusgo/hot reload custom shaders 2

### DIFF
--- a/hotham-asset-server/src/main.rs
+++ b/hotham-asset-server/src/main.rs
@@ -14,7 +14,7 @@ use futures_util::StreamExt;
 // 5. GOTO 2
 use server::{handle_connection, make_server_endpoint, watch_files};
 
-pub type WatchList = Arc<Mutex<HashMap<String, SystemTime>>>;
+pub type WatchList = Arc<Mutex<HashMap<String, anyhow::Result<SystemTime>>>>;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/hotham-asset-server/src/server.rs
+++ b/hotham-asset-server/src/server.rs
@@ -147,11 +147,12 @@ async fn get_asset(path: &str) -> Result<Vec<u8>> {
 }
 
 async fn get_last_updated(path: &str) -> SystemTime {
-    tokio::fs::metadata(path)
-        .await
-        .unwrap()
-        .modified()
-        .expect("[SERVER] TIME SHENNANIGANS HAVE OCURRED!")
+    match tokio::fs::metadata(path).await {
+        Ok(metadata) => metadata
+            .modified()
+            .expect("[SERVER] TIME SHENNANIGANS HAVE OCURRED!"),
+        Err(_) => SystemTime::UNIX_EPOCH.clone(),
+    }
 }
 
 pub fn make_server_endpoint(bind_addr: SocketAddr) -> Result<(Incoming, Vec<u8>), Box<dyn Error>> {

--- a/hotham/src/engine.rs
+++ b/hotham/src/engine.rs
@@ -292,14 +292,15 @@ impl Engine {
                     let world = &mut self.world;
 
                     let file_type = asset_updated.asset_id.split('.').last().unwrap();
-                    match file_type {
-                        "glb" => update_models(
+                    match (asset_updated.asset_id.as_str(), file_type) {
+                        (_, "glb") => update_models(
                             vulkan_context,
                             render_context,
                             world,
                             asset_updated.asset_data,
                         ),
-                        "spv" => update_shader(
+                        ("hotham/src/shaders/pbr.frag.spv", _)
+                        | ("hotham/src/shaders/pbr.vert.spv", _) => update_shader(
                             vulkan_context,
                             render_context,
                             &asset_updated.asset_id,

--- a/hotham/src/engine.rs
+++ b/hotham/src/engine.rs
@@ -5,7 +5,7 @@ use crate::{
         render_context::create_pipeline, AudioContext, GuiContext, HapticContext, InputContext,
         PhysicsContext, RenderContext, VulkanContext, XrContext, XrContextBuilder,
     },
-    util::PerformanceTimer,
+    util::{u8_to_u32, PerformanceTimer},
     workers::Workers,
     HothamError, HothamResult, VIEW_TYPE,
 };
@@ -393,20 +393,6 @@ fn update_shader(
         )
         .unwrap();
     }
-}
-
-// shout out to wgpu to for this:
-fn u8_to_u32(asset_data: Arc<Vec<u8>>) -> Vec<u32> {
-    let mut words = vec![0u32; asset_data.len() / std::mem::size_of::<u32>()];
-    unsafe {
-        std::ptr::copy_nonoverlapping(
-            asset_data.as_ptr(),
-            words.as_mut_ptr() as *mut u8,
-            asset_data.len(),
-        );
-    }
-
-    words
 }
 
 fn despawn_children(

--- a/hotham/src/util.rs
+++ b/hotham/src/util.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use glam::{Affine3A, Quat, Vec3};
 use openxr::{Posef, SpaceLocation, SpaceLocationFlags, ViewStateFlags};
 use rapier3d::na::Vector3;
-use std::{ffi::CStr, os::raw::c_char, str::Utf8Error, time::Instant};
+use std::{ffi::CStr, os::raw::c_char, str::Utf8Error, sync::Arc, time::Instant};
 
 pub(crate) unsafe fn get_raw_strings(strings: Vec<&str>) -> Vec<*const c_char> {
     strings
@@ -26,6 +26,21 @@ pub(crate) unsafe fn parse_raw_string(
 ) -> Result<&'static str, Utf8Error> {
     let cstr = CStr::from_ptr(raw_string);
     cstr.to_str()
+}
+
+// shout out to wgpu to for this:
+/// Creates a new vec with a copy of the same bytes.
+pub fn u8_to_u32(asset_data: Arc<Vec<u8>>) -> Vec<u32> {
+    let mut words = vec![0u32; asset_data.len() / std::mem::size_of::<u32>()];
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            asset_data.as_ptr(),
+            words.as_mut_ptr() as *mut u8,
+            asset_data.len(),
+        );
+    }
+
+    words
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR replaces #422.

All assets which are received by the hot reloading are exposed by `engine.get_updated_assets()`. This enables the custom rendering example to look for its shaders and update them. It could also be used for other assets in the future.