### PR TITLE
Fix dummy keystore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,4 @@ test_assets/culling_stress_test.glb filter=lfs diff=lfs merge=lfs -text
 hotham/data/brdf_lut.ktx2 filter=lfs diff=lfs merge=lfs -text
 hotham/data/environment_map_diffuse.ktx2 filter=lfs diff=lfs merge=lfs -text
 hotham/data/environment_map_specular.ktx2 filter=lfs diff=lfs merge=lfs -text
+*.keystore binary


### PR DESCRIPTION
Olly reported a problem with the dummy keystore:
> Hi!  Was able to get hotham working on my setup, but had the following minor issue, that others might encounter.  I was building from an OSX environment and the dummy keystore was hilighted as invalid when I tried to run the build on my device.  I think this is because the ./examples/hotham_examples.keystore file was checked in as text instead of binary.  I regenerated a keystore locally and was able to upload the apk, but you might want to mark the file as binary, so that others won't hit this problem from an "out of the box" experience.

> I think adding the following to .gitattributes should do the trick:
`*.keystore binary`

This is an attempt at the suggested solution.