### PR TITLE
Improvements to grabbing system. Closes #432

### DIFF
--- a/hotham/src/components/grabbable.rs
+++ b/hotham/src/components/grabbable.rs
@@ -1,2 +1,8 @@
 #[derive(Debug, Clone, Copy)]
 pub struct Grabbable {}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Grabbed;
+
+#[derive(Debug, Clone, Copy)]
+pub struct Released;

--- a/hotham/src/components/mod.rs
+++ b/hotham/src/components/mod.rs
@@ -23,7 +23,7 @@ pub mod visible;
 pub use animation_controller::AnimationController;
 pub use animation_target::AnimationTarget;
 pub use global_transform::GlobalTransform;
-pub use grabbable::Grabbable;
+pub use grabbable::*;
 pub use hand::Hand;
 pub use hmd::HMD;
 pub use info::Info;

--- a/hotham/src/systems/hands.rs
+++ b/hotham/src/systems/hands.rs
@@ -2,7 +2,7 @@ use crate::{
     asset_importer::add_model_to_world,
     components::{
         global_transform::GlobalTransform, hand::Handedness, local_transform::LocalTransform,
-        stage, AnimationController, Collider, Hand,
+        stage, AnimationController, Collider, Grabbed, Hand,
     },
     contexts::{physics_context::HAND_COLLISION_GROUP, InputContext},
     Engine,
@@ -52,11 +52,18 @@ pub fn hands_system_inner(world: &mut World, input_context: &InputContext) {
 
         // If we've grabbed something, update its transform, being careful to preserve its scale.
         if let Some(grabbed_entity) = hand.grabbed_entity {
-            let mut local_transform = world.get::<&mut LocalTransform>(grabbed_entity).unwrap();
-            local_transform.update_rotation_translation_from_affine(&global_from_local);
+            // We first need to check if some other system has decided that this item should no longer be grabbed.
+            if !world.entity(grabbed_entity).unwrap().has::<Grabbed>() {
+                hand.grabbed_entity = None;
+            } else {
+                // OK. We are sure that this entity exists, and is being grabbed.
+                let mut local_transform = world.get::<&mut LocalTransform>(grabbed_entity).unwrap();
+                local_transform.update_rotation_translation_from_affine(&global_from_local);
 
-            let mut global_transform = world.get::<&mut GlobalTransform>(grabbed_entity).unwrap();
-            *global_transform = (*local_transform).into();
+                let mut global_transform =
+                    world.get::<&mut GlobalTransform>(grabbed_entity).unwrap();
+                *global_transform = (*local_transform).into();
+            }
         }
 
         // Apply grip value to hand
@@ -133,6 +140,7 @@ mod tests {
 
         let expected_scale = Vec3::X * 1000.;
         let grabbed_entity = world.spawn((
+            Grabbed,
             RigidBody::default(),
             LocalTransform {
                 scale: expected_scale,
@@ -149,6 +157,25 @@ mod tests {
 
         // Make sure that scale gets preserved
         assert_relative_eq!(local_transform.scale, expected_scale);
+    }
+
+    #[test]
+    pub fn test_ungrabbed_object_do_not_move() {
+        let (mut world, input_context) = setup();
+
+        let grabbed_entity = world.spawn((
+            RigidBody::default(),
+            LocalTransform::default(),
+            GlobalTransform::default(),
+        ));
+        add_hand_to_world(&mut world, Some(grabbed_entity));
+
+        tick(&mut world, &input_context);
+
+        let local_transform = world.get::<&mut LocalTransform>(grabbed_entity).unwrap();
+        assert_relative_eq!(local_transform.translation, Default::default());
+        assert_relative_eq!(local_transform.scale, Vec3::ONE);
+        assert_relative_eq!(local_transform.rotation, Default::default());
     }
 
     // HELPER FUNCTIONS


### PR DESCRIPTION
## What is this related to?
#432

## What changed?
Added two new components, `Grabbed` and `Released` to make it easier for other systems to interact with held objects. This has been tested on The Station and has proved to work very well.

## What is the overall impact?
It should now be possible to implement "socket" type mechanics where a player picks up an object, inserts it into a socket and then releases it, without having to run systems multiple times or other hacks.