### PR TITLE
Rasmusgo/xr time now

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,7 @@
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
     "files.trimTrailingWhitespace": true,
+    // Uncomment this to tell rust-analyzer to treat the code as being compiled for android.
+    // "rust-analyzer.cargo.target": "aarch64-linux-android",
     "webgl-glsl-editor.format.placeSpaceAfterKeywords": true
 }

--- a/hotham/Cargo.toml
+++ b/hotham/Cargo.toml
@@ -51,3 +51,6 @@ serde_json = "1.0"
 jni = "0.19.0"
 ndk = "0.6"
 ndk-glue = "0.6"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = {version = "0.48", features = ["Win32_Foundation", "Win32_System_Performance"]}

--- a/hotham/Cargo.toml
+++ b/hotham/Cargo.toml
@@ -54,3 +54,6 @@ ndk-glue = "0.6"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = {version = "0.48", features = ["Win32_Foundation", "Win32_System_Performance"]}
+
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+libc = "0.2"

--- a/hotham/src/contexts/xr_context/mod.rs
+++ b/hotham/src/contexts/xr_context/mod.rs
@@ -15,6 +15,7 @@ use crate::{
 };
 
 mod input;
+mod time;
 use input::Input;
 
 #[derive(Default)]

--- a/hotham/src/contexts/xr_context/time.rs
+++ b/hotham/src/contexts/xr_context/time.rs
@@ -3,7 +3,7 @@ use crate::HothamResult;
 
 #[cfg(target_os = "windows")]
 impl XrContext {
-    pub fn now(self: &Self) -> HothamResult<openxr::Time> {
+    pub fn now(&self) -> HothamResult<openxr::Time> {
         if let Some(ext) = &self
             .instance
             .exts()
@@ -45,7 +45,7 @@ fn get_performance_counter() -> Result<i64, windows::core::Error> {
 
 #[cfg(not(target_os = "windows"))]
 impl XrContext {
-    pub fn now(self: &Self) -> HothamResult<openxr::Time> {
+    pub fn now(&self) -> HothamResult<openxr::Time> {
         if let Some(ext) = &self.instance.exts().khr_convert_timespec_time {
             let mut xr_time = openxr::Time::from_nanos(0);
             let timespec_time = now_monotonic();

--- a/hotham/src/contexts/xr_context/time.rs
+++ b/hotham/src/contexts/xr_context/time.rs
@@ -1,0 +1,51 @@
+use super::XrContext;
+use crate::HothamResult;
+
+#[cfg(target_os = "windows")]
+impl XrContext {
+    pub fn now(self: &Self) -> HothamResult<openxr::Time> {
+        if let Some(ext) = &self
+            .instance
+            .exts()
+            .khr_win32_convert_performance_counter_time
+        {
+            let mut xr_time = openxr::Time::from_nanos(0);
+            let performance_counter = get_performance_counter().unwrap();
+            match unsafe {
+                (ext.convert_win32_performance_counter_to_time)(
+                    self.instance.as_raw(),
+                    &performance_counter,
+                    &mut xr_time,
+                )
+            } {
+                openxr::sys::Result::SUCCESS => Ok(xr_time),
+                _ => Err(anyhow::anyhow!(
+                    "OpenXR convert_win32_performance_counter_to_time failed."
+                )
+                .into()),
+            }
+        } else {
+            Err(anyhow::anyhow!(
+                "OpenXR extension khr_win32_convert_performance_counter_time needs to be enabled. \
+                Enable it via XrContextBuilder::required_extensions()."
+            )
+            .into())
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn get_performance_counter() -> Result<i64, windows::core::Error> {
+    unsafe {
+        let mut time = 0;
+        windows::Win32::System::Performance::QueryPerformanceCounter(&mut time).ok()?;
+        Ok(time)
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+impl XrContext {
+    pub fn now(self: &Self) -> HothamResult<openxr::Time> {
+        todo!("XrContext::now() is not yet implemented for non-windows platforms.")
+    }
+}

--- a/hotham/src/engine.rs
+++ b/hotham/src/engine.rs
@@ -31,29 +31,11 @@ pub static ANDROID_LOOPER_NONBLOCKING_TIMEOUT: Duration = Duration::from_millis(
 pub static ANDROID_LOOPER_BLOCKING_TIMEOUT: Duration = Duration::from_millis(i32::MAX as _);
 
 /// Builder for `Engine`.
+#[derive(Default)]
 pub struct EngineBuilder<'a> {
     application_name: Option<&'a str>,
     application_version: Option<u32>,
     openxr_extensions: Option<xr::ExtensionSet>,
-}
-
-impl<'a> Default for EngineBuilder<'a> {
-    fn default() -> Self {
-        let mut extensions = xr::ExtensionSet::default();
-        #[cfg(target_os = "windows")]
-        {
-            extensions.khr_win32_convert_performance_counter_time = true;
-        }
-        #[cfg(not(target_os = "windows"))]
-        {
-            extensions.khr_convert_timespec_time = true;
-        }
-        Self {
-            application_name: Default::default(),
-            application_version: Default::default(),
-            openxr_extensions: Some(extensions),
-        }
-    }
 }
 
 impl<'a> EngineBuilder<'a> {

--- a/hotham/src/engine.rs
+++ b/hotham/src/engine.rs
@@ -31,11 +31,29 @@ pub static ANDROID_LOOPER_NONBLOCKING_TIMEOUT: Duration = Duration::from_millis(
 pub static ANDROID_LOOPER_BLOCKING_TIMEOUT: Duration = Duration::from_millis(i32::MAX as _);
 
 /// Builder for `Engine`.
-#[derive(Default)]
 pub struct EngineBuilder<'a> {
     application_name: Option<&'a str>,
     application_version: Option<u32>,
     openxr_extensions: Option<xr::ExtensionSet>,
+}
+
+impl<'a> Default for EngineBuilder<'a> {
+    fn default() -> Self {
+        let mut extensions = xr::ExtensionSet::default();
+        #[cfg(target_os = "windows")]
+        {
+            extensions.khr_win32_convert_performance_counter_time = true;
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            extensions.khr_convert_timespec_time = true;
+        }
+        Self {
+            application_name: Default::default(),
+            application_version: Default::default(),
+            openxr_extensions: Some(extensions),
+        }
+    }
 }
 
 impl<'a> EngineBuilder<'a> {


### PR DESCRIPTION
This PR adds a method that retrieves the current time as a `openxr::Time` that can be passed to openxr instead of predicted display time to get more accurate poses with the trade-off that they will be old when the frame is done rendering and displayed to the user.

This function relies on the appropriate time conversion extension being enabled. It can be enabled when creating the engine like this:

```rs
    let mut extensions = xr::ExtensionSet::default();
    #[cfg(windows)]
    {
        extensions.khr_win32_convert_performance_counter_time = true;
    }
    #[cfg(not(windows))]
    {
        extensions.khr_convert_timespec_time = true;
    }
    let extensions = Some(extensions);
    let mut engine_builder = EngineBuilder::new();
    engine_builder.openxr_extensions(extensions);
    let mut engine = engine_builder.build();
```
_(I couldn't get it prettier because of moving mut and temporary variables being dropped. The builder pattern could probably be made to work better.)_