### PR TITLE
Create shell.nix for quick Nix(OS) setup

### DIFF
--- a/examples/crab-saber/scripts/run_on_device.sh
+++ b/examples/crab-saber/scripts/run_on_device.sh
@@ -6,7 +6,7 @@ adb shell am force-stop rust.crab_saber
 scriptdir=$(dirname -- "$(realpath -- "$0")")
 cd $scriptdir/..
 
-cargo apk run --release
+cargo apk run --release --package crab-saber
 
 # Wait for the app to start
 for i in 1 2 3 4 5; do

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,55 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+# based on https://nixos.org/manual/nixpkgs/stable/#android
+# note: if you get any weird errors of "required extensions not found" or the like, somehow hotham
+# doesn't search /run/opengl-driver
+# you can set VK_ICD_FILENAMES manually instead, see https://nixos.org/manual/nixos/stable/index.html#sec-gpu-accel-vulkan
+let
+  cmakeVersion = "3.22.1";
+
+  androidComposition = pkgs.androidenv.composeAndroidPackages {
+    includeNDK = true;
+    ndkVersion = "22.1.7171670";
+    platformVersions = ["28"];
+    cmakeVersions = [cmakeVersion];
+  };
+
+  openXrDropin = {
+    file_format_version = "1.0.0";
+    runtime = {
+      api_version = "1.0";
+      name = "Hotham Simulator";
+      # this won't work with pure flakes but flakes are unstable anyway
+      library_path = "${toString ./.}/target/debug/libhotham_simulator.so";
+    };
+  };
+in
+pkgs.mkShell rec {
+  ANDROID_SDK_ROOT = "${androidComposition.androidsdk}/libexec/android-sdk";
+  ANDROID_NDK_ROOT = "${ANDROID_SDK_ROOT}/ndk-bundle";
+
+  buildInputs = with pkgs; [
+    rustup ninja cmake
+    openssl pkg-config
+    cargo-apk
+
+    shaderc
+    vulkan-headers vulkan-loader
+    vulkan-tools vulkan-tools-lunarg
+    vulkan-validation-layers vulkan-extension-layer
+    monado openxr-loader openxr-loader.dev
+
+    libxkbcommon
+    wayland xorg.libX11 xorg.libXcursor xorg.libXrandr xorg.libXi
+    fontconfig freetype
+    alsa-lib
+
+    renderdoc
+  ];
+
+  shellHook = ''
+    export PATH="$(echo "$ANDROID_SDK_ROOT/cmake/${cmakeVersion}".*/bin):$PATH"
+    export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${builtins.toString (pkgs.lib.makeLibraryPath buildInputs)}";
+    export XR_RUNTIME_JSON="${builtins.toFile "hotham-openxr-runtime.json" (builtins.toJSON openXrDropin)}"
+  '';
+}


### PR DESCRIPTION
This allows nix or NixOS users to just run `nix-shell` in the repo and get almost everything listed in the [getting started guide](https://github.com/leetvr/hotham/wiki/Getting-started) up and running automagically. Worth noting that following steps need to be taken manually:

- Git LFS needs to be set up manually, if it's not installed user-wide already.
- The Android SDK license has to be accepted manually. If you run `nix-shell` the first time in this repo, it'll error, print the license and tell you how to accept it (through nixpkgs configuration).
- Most likely you'll need to set up udev rules for Android. This is also on the system level, though if on NixOS, setting `programs.adb.enable = true;` and adding your user to the `adbusers` group suffices, see [the Android page in the inofficial wiki](https://nixos.wiki/wiki/Android).
- For the simulator, there needs to be a working Vulkan setup. This is configured on the system level and also a bit manufacturer-dependent, though if on NixOS, following the advice in the manual (https://nixos.org/manual/nixos/stable/index.html#sec-gpu-accel-vulkan) did the job for me.

Adding `--package crab-saber` to the `cargo apk` command was required for me to get it even running, else it complained about not being sure which workspace member to pick.

**Note:** Since I have no VR device, Android deployment was tested using my mobile phone. I did observe the app building and launching on my phone, however, it gave no display output (but errored still just fine and displayed that on the host PC).
